### PR TITLE
55 fix center and align

### DIFF
--- a/TCL/helpers/BinTools.tcl
+++ b/TCL/helpers/BinTools.tcl
@@ -10,20 +10,19 @@ proc DtoR {d} {
 }
 
 
-;# Centers around the protien and centers the system at 0,0,0
-proc Center { stuff } {
-    pbc wrap -center com -centersel ${stuff} -orthorhombic  -all
+;# Centers the system at 0,0,0
+proc center_at_origin {} {
     set nframes [molinfo top get numframes]
     set zero [veczero]
+    set sel [atomselect top "all"]
     for {set frames 0} {$frames < $nframes} {incr frames} {
-        set sel [atomselect top "all" frame $frames]
+        $sel frame $frames
+        $sel update
         set com [measure center $sel]
-        $sel delete
-        set sell [atomselect top "all" frame $frames]
         set mov [vecsub $zero $com]
-        $sell moveby $mov
-        $sell delete
+        $sel moveby $mov
     }
+    $sel delete
 }
 
 ;# Alignment based off vmd alignment

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -179,12 +179,14 @@ proc center_and_wrap_system {inpt} {
         }
         
         if {($params(use_qwrap)==0) || (([lindex $pbc_angles 0]!=90.0) && ([lindex $pbc_angles 0]!=90.0) && ([lindex $pbc_angles 0]!=90.0))} {
-            puts "qwrap may not be optimal for your system...\n"
-            puts "Running pbc wrap. To verify proper centering"
-            puts "pbc wrap will be run multiple times" ; after 100
-            foreach i {0 1 2 3} {
-                pbc wrap -centersel "$inpt" -all
+            if {$params(use_qwrap)!=0} {
+                puts "qwrap requires orthorhombic cells.\n"
+                puts "Running pbc wrap instead and centering system at origin."
+            } else {
+                puts "Running pbc wrap and centering system at origin."
             }
+            pbc wrap -center com -centersel ${inpt} -all
+            center_at_origin
         } else {
             qwrap centersel "$inpt" ;#center entire system at ~0,0,0
         }

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -186,6 +186,7 @@ proc center_and_wrap_system {inpt} {
             return
         }
         
+        ;# use qwrap or pbc wrap and center at origin
         if {($params(use_qwrap)==0) || ($orthorhombic!=1) } {
             if {$params(use_qwrap)!=0} {
                 puts "qwrap requires orthorhombic cells.\n"
@@ -196,13 +197,16 @@ proc center_and_wrap_system {inpt} {
             pbc wrap -center com -centersel ${inpt} -all
             center_at_origin
         } else {
+            ;# qwrap automatically centers $inpt at origin
             qwrap centersel "$inpt"
         }
 
+        ;# update the COM and counter
         $sel update
         set com [measure center $sel weight mass]
         incr counter_i
     }
+    
     $sel delete
 }
 

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -555,10 +555,9 @@ proc polarDensityBin { config_file_script } {
         if {$sel_num == 0} {
             error "No lipid of species $species"
         }
-        ;# Center's system (weak hack)
+
         if {$params(center_and_align) == 1} {
-            center_and_wrap_system "occupancy $params(helixlist) and $params(backbone_selstr)"
-            center_and_wrap_system "occupancy $params(helixlist) and $params(backbone_selstr)"
+            ;# wraps and centers system at origin
             center_and_wrap_system "occupancy $params(helixlist) and $params(backbone_selstr)"
             ;# aligns protein
             Align "occupancy $params(helixlist) and $params(backbone_selstr)"

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -186,8 +186,8 @@ proc center_and_wrap_system {inpt} {
             return
         }
         
-        ;# use qwrap or pbc wrap and center at origin
         if {($params(use_qwrap)==0) || ($orthorhombic!=1) } {
+            ;# use pbc wrap and center at origin
             if {$params(use_qwrap)!=0} {
                 puts "qwrap requires orthorhombic cells.\n"
                 puts "Running pbc wrap instead and centering system at origin."
@@ -197,7 +197,7 @@ proc center_and_wrap_system {inpt} {
             pbc wrap -center com -centersel ${inpt} -all
             center_at_origin
         } else {
-            ;# qwrap automatically centers $inpt at origin
+            ;# use qwrap (automatically centers at origin)
             qwrap centersel "$inpt"
         }
 
@@ -206,7 +206,7 @@ proc center_and_wrap_system {inpt} {
         set com [measure center $sel weight mass]
         incr counter_i
     }
-    
+
     $sel delete
 }
 

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -157,8 +157,7 @@ proc avg_acyl_chain_len {species acylchain_selstr} {
     
 }
 
-;# confirms your box is either square or paraelleogram-ish
-;# will perform qwrap or pbc wrap depending
+;# will perform qwrap or pbc wrap, depending on settings and box angles
 proc center_and_wrap_system {inpt} {
     global params
     set counter_i 0

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -190,6 +190,7 @@ proc center_and_wrap_system {inpt} {
         } else {
             qwrap centersel "$inpt" ;#center entire system at ~0,0,0
         }
+        $sel update
         set com [measure center $sel weight mass]
         incr counter_i
     }

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -180,7 +180,7 @@ proc center_and_wrap_system {inpt} {
         ;# time-out trigger
         if {$counter_i > 5} {
             puts "Script was unable to converge system to (0,0,0)"
-            puts "Please check your system vissually, there may be"
+            puts "Please check your system visually, there may be"
             puts "unintended artifacts"
             $sel delete
             return
@@ -539,7 +539,6 @@ proc set_parameters { config_file_script } {
 
 proc polarDensityBin { config_file_script } { 
     ;#read parameters
-    #source $config_file_script
     global params
     set_parameters $config_file_script
     source $params(utils)/BinTools.tcl


### PR DESCRIPTION
Resolves issue #55 : using the center_and_align option will now center your protein at the origin, regardless of whether you are using qwrap or pbc wrap. Also, I cleaned up the code a little.

Tested the code on a toy system; desired results achieved without errors.