### PR TITLE
65 leaflet sorter 2 should be more flexible

### DIFF
--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -253,19 +253,22 @@ proc leaflet_sorter_1 {atsel_in frame_i} {
 
 ;#originally by Jahmal Ennis, designed for cholesterol 
 ;# modified by Jesse Sandberg to be more flexible
-proc leaflet_sorter_2 {atsel_in refsel_in frame_i} {    
+proc leaflet_sorter_2 {atsel_in refsel_in frame_i} { 
     set lipidsel [atomselect top "$atsel_in" frame $frame_i]
     set refsel [atomselect top "$refsel_in" frame $frame_i]
     set refsel_com_z [lindex [measure center $refsel weight mass] 2]
-    set chol_com_z [lindex [measure center $lipidsel weight mass] 2]
-    if {$chol_com_z < $refsel_com_z} {
-        $sel_resid set user2 -1
+    set lipid_com_z [lindex [measure center $lipidsel weight mass] 2]
+    if {$lipid_com_z < $refsel_com_z} {
+        $lipidsel set user2 -1
+        $lipidsel delete
+        $refsel delete
         return -1
     } else {
-        $sel_resid set user2 1
+        $lipidsel set user2 1
+        $lipidsel delete
+        $refsel delete
         return 1
     }
-
 }
 
 
@@ -275,6 +278,7 @@ proc leaflet_sorter_2 {atsel_in refsel_in frame_i} {
 ;# 1: originally by Liam Sharp; procedure that was used in JCP 2021 for nAChR; similar to leaflet_sorter_0 but autoselects head and tail beads; more appropriate for situations with many species
 ;# 2: originally by Jahmal Ennis, determines whether the auto-determined headbead is above or below the center of mass (of what? the system?); more appropriate for rigid lipids like cholesterol that frequently invert or lie at parallel to the membrane
 proc leaflet_detector {atsel_in head tail frame_i leaflet_sorting_algorithm} {
+    global params
     if {$leaflet_sorting_algorithm == 0} {
         leaflet_sorter_0 $atsel_in $head $tail $frame_i
     } elseif { $leaflet_sorting_algorithm == 1 } {
@@ -308,6 +312,7 @@ proc frame_leaflet_assignment {species headname tailname lipidbeads_selstr frame
         set leaflet_list [$sel get user2] 
         for {set interim_frame [expr $frame_i + 1]} {$interim_frame < [expr $frame_f]} {incr interim_frame} {
             $sel frame $interim_frame
+            $sel update
             $sel set user2 $leaflet_list
         }
         #count the number of lipids and the number of beads in each leaflet
@@ -474,6 +479,7 @@ proc set_parameters { config_file_script } {
     global params
     array set params {
         leaflet_sorting_algorithm 1
+        leaflet_sorter_2_reference_sel "none"
         center_and_align 0
         use_qwrap 0
         utils ./helpers 

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -252,27 +252,20 @@ proc leaflet_sorter_1 {atsel_in frame_i} {
 }
 
 ;#originally by Jahmal Ennis, designed for cholesterol 
-proc leaflet_sorter_2 {atsel_in frame_i} {
+;# modified by Jesse Sandberg to be more flexible
+proc leaflet_sorter_2 {atsel_in refsel_in frame_i} {    
+    set lipidsel [atomselect top "$atsel_in" frame $frame_i]
+    set refsel [atomselect top "$refsel_in" frame $frame_i]
+    set refsel_com_z [lindex [measure center $refsel weight mass] 2]
+    set chol_com_z [lindex [measure center $lipidsel weight mass] 2]
+    if {$chol_com_z < $refsel_com_z} {
+        $sel_resid set user2 -1
+        return -1
+    } else {
+        $sel_resid set user2 1
+        return 1
+    }
 
-    #puts "Sorting into leaflets using leaflet_sorter_2"
-    set sel_resid [atomselect top "$atsel_in" frame $frame_i]
-    set ind 1
-    if { [string range [lsort -unique [$sel_resid get resname]] end-1 end] == "PA" } {
-        set ind 0
-    }
-    if { [lsort -unique [$sel_resid get resname]] == "CHOL" } {
-        set ind 2
-    }
-    if { $ind == 2 } {
-        set chol_com_z [lindex [measure center $sel_resid weight mass] end]
-        if {$chol_com_z < 0} {
-            $sel_resid set user2 -1
-            return -1
-        } else {
-            $sel_resid set user2 1
-            return 1
-        }
-    }
 }
 
 
@@ -287,7 +280,7 @@ proc leaflet_detector {atsel_in head tail frame_i leaflet_sorting_algorithm} {
     } elseif { $leaflet_sorting_algorithm == 1 } {
         leaflet_sorter_1 $atsel_in $frame_i
     } elseif { $leaflet_sorting_algorithm == 2 } {
-        leaflet_sorter_2 $atsel_in $frame_i
+        leaflet_sorter_2 $atsel_in $params(leaflet_sorter_2_reference_sel) $frame_i
     } else { 
         puts "Option $leaflet_sorting_algorithm not recognized as a leaflet sorting option.  Defaulting to option 1." 
     }

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -261,18 +261,16 @@ proc leaflet_sorter_2 {atsel_in refsel_in frame_i} {
     } else {
         set refsel [atomselect top "$refsel_in" frame $frame_i]
         set refsel_com_z [lindex [measure center $refsel weight mass] 2]
+        $refsel delete
     }
     set lipidsel [atomselect top "$atsel_in" frame $frame_i]
     set lipid_com_z [lindex [measure center $lipidsel weight mass] 2]
+    $lipidsel delete
     if {$lipid_com_z < $refsel_com_z} {
         $lipidsel set user2 -1
-        $lipidsel delete
-        $refsel delete
         return -1
     } else {
         $lipidsel set user2 1
-        $lipidsel delete
-        $refsel delete
         return 1
     }
 }

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -254,9 +254,15 @@ proc leaflet_sorter_1 {atsel_in frame_i} {
 ;#originally by Jahmal Ennis, designed for cholesterol 
 ;# modified by Jesse Sandberg to be more flexible
 proc leaflet_sorter_2 {atsel_in refsel_in frame_i} { 
+    if {$refsel_in eq "none"} {
+        puts "No reference selection provided for leaflet sorter 2."
+        puts "Defaulting to z=0 as the reference height to sort by."
+        set refsel_com_z 0
+    } else {
+        set refsel [atomselect top "$refsel_in" frame $frame_i]
+        set refsel_com_z [lindex [measure center $refsel weight mass] 2]
+    }
     set lipidsel [atomselect top "$atsel_in" frame $frame_i]
-    set refsel [atomselect top "$refsel_in" frame $frame_i]
-    set refsel_com_z [lindex [measure center $refsel weight mass] 2]
     set lipid_com_z [lindex [measure center $lipidsel weight mass] 2]
     if {$lipid_com_z < $refsel_com_z} {
         $lipidsel set user2 -1


### PR DESCRIPTION
leaflet sorter 2 now takes a reference selection (specified in the config file) to compare against, rather than just using z=0 as the yardstick to sort by.