### PR TITLE
22 get cmap is deprecated in matplotlib

### DIFF
--- a/python/plotting.py
+++ b/python/plotting.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Mon Nov 11 14:41:24 2024.
+
+@author: js2746
+"""
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.colors import ListedColormap
+
+
+def make_custom_colormap():
+    """
+    Make a custom colormap for plotting.
+
+    Returns
+    -------
+    my_cmap : matplotlib colormap
+        The colormap to use when plotting.
+
+    """
+    depleted = plt.colormaps['RdGy_r']
+    enriched = plt.colormaps['bwr']
+    newcolors = np.concatenate([depleted(np.linspace(0.35, 0.5, 128)), enriched(np.linspace(0.5, 1, 128))])
+    my_cmap = ListedColormap(newcolors)
+    return my_cmap

--- a/python/plotting.py
+++ b/python/plotting.py
@@ -12,7 +12,9 @@ from matplotlib.colors import ListedColormap
 
 def make_custom_colormap():
     """
-    Make a custom colormap for plotting.
+    Make a custom colormap for plotting. The colormap starts at 0.35 to ensure \
+    that there is a visual difference between 0 (no signal) and depleted (near-\
+    zero enrichment).
 
     Returns
     -------

--- a/python/preliminaries.ipynb
+++ b/python/preliminaries.ipynb
@@ -16,21 +16,9 @@
     "from DTA.enrichment_plotters import polar_plot, get_file_list, get_helices, read_rep\n",
     "from DTA.polarDensity_helper import Coord_Get, get_header_info\n",
     "from DTA.site_distributions import outline_site, make_symmetric_sites, combine_sites, plot_density, Site\n",
+    "from plotting import make_custom_colormap\n",
+    "my_cmap = make_custom_colormap()\n",
     "plt.rcParams['axes.grid'] = False "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Enrichment plot colormap\n",
-    "from matplotlib.colors import ListedColormap\n",
-    "depleted = plt.cm.get_cmap('RdGy_r', 256)\n",
-    "enriched = plt.cm.get_cmap('bwr', 256)\n",
-    "newcolors = np.concatenate([depleted(np.linspace(0.35, 0.5, 128)), enriched(np.linspace(0.5,1,128))])\n",
-    "my_cmap = ListedColormap(newcolors)"
    ]
   },
   {
@@ -382,7 +370,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "jupEnv",
+   "display_name": "base",
    "language": "python",
    "name": "python3"
   },
@@ -396,7 +384,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Description
This fixes a Warning from matplotlib and replaces a code block in the notebook with a one-line function call. Plotting.py is now a file that will continue to grow as we add PRs.

## Usage Changes
No user-impacting changes (other than the user no longer gets a Warning and the user sees slightly less unecessary code)

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Replaces deprecated matplotlib command with modern one
  - [x] repackages all colormap lines into one function called make_custom_colormap()

## Pre-Review checklist (PR maker)
- [x] Does the figure look the same no matter which cmap you use?
- [x] New functions are documented
- [x] Make a testing nb

## Review checklist (Reviewer)
- [x] put the cmap_test notebook in the python directory of DTA, add a lipid and a path, and run the cells.
[cmap_test.zip](https://github.com/user-attachments/files/17707796/cmap_test.zip)
- [x] Do the two heatmap figures look identical?
- [x] New functions are documented 
- [x] New functions/variables are named appropriately
- [x] I understand what the changes are doing and how
- [x] I understand the motivation for this PR (the PR itself is appropriately documented)

## Status
- [x] Ready for review