### PR TITLE
92 leaflet sorter 3 fails when lipids split across pb

### DIFF
--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -282,23 +282,13 @@ proc leaflet_sorter_2 {atsel_in refsel_in frame_i} {
 ;# Compares lipid's COM z component to local midplane and sorts accordingly.
 proc leaflet_sorter_3 {atsel_in frame_i} {
     set lipidsel [atomselect top $atsel_in frame $frame_i]
-    puts [$lipidsel num]
     set lipid_com [measure center $lipidsel weight mass]
     set lipid_x [lindex $lipid_com 0]
     set lipid_y [lindex $lipid_com 1]
     set lipid_z [lindex $lipid_com 2]
     
-    set local_surfaces [atomselect top "name PO4 GL1 GL2 AM1 AM2 and (x-$lipid_x)*(x-$lipid_x)+(y-$lipid_y)*(y-$lipid_y)<200" frame $frame_i]
-
-    if { [catch {set local_midplane [lindex [measure center $local_surfaces weight mass] 2]} errid] } {
-        puts stderr "$errid"
-        $lipidsel set user2 3
-        $lipidsel delete
-        $local_surfaces delete
-        return 3
-    } else {
-        set local_midplane [lindex [measure center $local_surfaces weight mass] 2]
-    }
+    set local_surfaces [atomselect top "name PO4 GL1 GL2 AM1 AM2 and pbwithin 200 of $atsel_in" frame $frame_i]
+    set local_midplane [lindex [measure center $local_surfaces weight mass] 2]
     $local_surfaces delete
 
     if {$lipid_z < $local_midplane} {

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -282,13 +282,23 @@ proc leaflet_sorter_2 {atsel_in refsel_in frame_i} {
 ;# Compares lipid's COM z component to local midplane and sorts accordingly.
 proc leaflet_sorter_3 {atsel_in frame_i} {
     set lipidsel [atomselect top $atsel_in frame $frame_i]
+    puts [$lipidsel num]
     set lipid_com [measure center $lipidsel weight mass]
     set lipid_x [lindex $lipid_com 0]
     set lipid_y [lindex $lipid_com 1]
     set lipid_z [lindex $lipid_com 2]
     
     set local_surfaces [atomselect top "name PO4 GL1 GL2 AM1 AM2 and (x-$lipid_x)*(x-$lipid_x)+(y-$lipid_y)*(y-$lipid_y)<200" frame $frame_i]
-    set local_midplane [lindex [measure center $local_surfaces weight mass] 2]
+
+    if { [catch {set local_midplane [lindex [measure center $local_surfaces weight mass] 2]} errid] } {
+        puts stderr "$errid"
+        $lipidsel set user2 3
+        $lipidsel delete
+        $local_surfaces delete
+        return 3
+    } else {
+        set local_midplane [lindex [measure center $local_surfaces weight mass] 2]
+    }
     $local_surfaces delete
 
     if {$lipid_z < $local_midplane} {


### PR DESCRIPTION
## Description
When local_midplane2 is run (leaflet_sorter_3), it has trouble at the borders of the box because it doesn't use pbwithin. Now it does use pbwithin and we no longer get intermittent errors when leaflet sorting.

## Usage Changes
None

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Switch leaflet_sorter_3 (local_midplane2) to use pbwithin instead of a radial distance that doesn't see PBCs

## Pre-Review checklist (PR maker)
- [x] Run this on test system and ensure that errors do not persist 
- [x] Run this on test system and ensure that performance is not worse

## Review checklist (Reviewer)
- [x] I understand what the changes are doing and how
- [x] I understand the motivation for this PR (the PR itself is appropriately documented)

## Status
- [x] Ready for review