### PR TITLE
site now has a dtheta attribute

### DIFF
--- a/python/DTA/site_distributions.py
+++ b/python/DTA/site_distributions.py
@@ -31,6 +31,7 @@ class Site:
     expPunocc: float=0
     theta_vals: list=None
     dr: float=0
+    dth: float=0
 
 def make_simple_site(the_data, inner_r=0, outer_r=0, nth=1, Ntheta=1, dr=1, dth=1, exrho=0, frames=1, the_thetas=None, title="", Npeak=None, accessible_area=None):
     """
@@ -74,6 +75,7 @@ def make_simple_site(the_data, inner_r=0, outer_r=0, nth=1, Ntheta=1, dr=1, dth=
 
     the_site.theta_vals = (the_thetas*dth)%(2*np.pi)
     the_site.dr = dr
+    the_site.dtheta = dth
     if Npeak is not None:
         the_site.Npeak = Npeak
     else:
@@ -287,8 +289,7 @@ def outline_site(ax, site):
     - matplotlib.axes.Axes: The modified matplotlib axes object with the binding site outlined.
     """
 
-    sorted_thetas = np.sort(site.theta_vals)
-    dtheta = sorted_thetas[1]-sorted_thetas[0]
+    dtheta = site.dtheta
     the_thetas = site.theta_vals-dtheta/2
     the_thetas = np.append(the_thetas, the_thetas[-1]+dtheta)
     ax.fill_between(the_thetas, site.inner_r, site.outer_r, facecolor=(0,0,0,0), edgecolor='k')

--- a/python/DTA/site_distributions.py
+++ b/python/DTA/site_distributions.py
@@ -31,7 +31,7 @@ class Site:
     expPunocc: float=0
     theta_vals: list=None
     dr: float=0
-    dth: float=0
+    dtheta: float=0
 
 def make_simple_site(the_data, inner_r=0, outer_r=0, nth=1, Ntheta=1, dr=1, dth=1, exrho=0, frames=1, the_thetas=None, title="", Npeak=None, accessible_area=None):
     """


### PR DESCRIPTION
## Description
Sites that were only one theta bin wide caused outline_site to fail because dtheta was being determined on the fly by outline_site without sufficient information to determine dtheta in the case that only one theta bin was provided. Now, dtheta is an attribute of the site that gets set by create_simple_site and gets accessed by outline_site.

## Usage Changes
None

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Creates dtheta attribute of Site
  - [x] dtheta is set by create_simple_site
  - [x] outline_site now correctly draws single-theta-bin sites

## Pre-Review checklist (PR maker)
- [x] Check to make sure outline_site gives desired results

## Review checklist (Reviewer)
- [x] Checkout branch 95-outline_site-cannot-calculate-dtheta-when-the-site-is-one-bin-wide
- [x] IMPORTANT!!!! re-install the DTA package (instructions on DTA repo readme)
[single-bin-test.zip](https://github.com/user-attachments/files/17818200/single-bin-test.zip)
- [x] Use the testing nb and confirm that outline_site correctly draws one-bin-wide sites
- [x] I understand what the changes are doing and how
- [x] I understand the motivation for this PR (the PR itself is appropriately documented)

## Status
- [x] Ready for review