### PR TITLE
Leaflet sorter speed up and shell selection bug fix

### DIFF
--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -583,12 +583,9 @@ proc polarDensityBin { config_file_script } {
     source $params(utils)/BinTools.tcl
 
     ;# check to make sure Rmax is evenly divisible by dr.
-    ;# Cannot ensure that Rmax and dr are both ints, so divisibility_test
-    ;# multiplies both by 10,000 before converting to int as a reasonable
-    ;# precaution. Specifying Rmax and dr to greater than 5 decimal places is
-    ;# a questionable life choice.
-    set divisibility_test [expr [expr int([expr $params(Rmax) * 10000])] % [expr int([expr $params(dr) * 10000])]]
-    if {$divisibility_test != 0} {
+    set divisibility_test [expr [expr double($params(Rmax))] % [expr double($params(dr))]]
+    set TOLERANCE [expr 10**-12]
+    if {$divisibility_test >= $TOLERANCE} {
         error "Rmax must be evenly divisible by dr."
     }
     

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -394,6 +394,19 @@ proc clean_leaflet_assignments {species lipidbeads_selstr} {
     $sel delete
 }
     
+#test to see if two floats are evenly divisible. Return 1 if evenly divisible.
+#Return 0 if not evenly divisible.
+proc test_if_evenly_divisible {dividend divisor} {
+    set TOLERANCE [expr 10.0**-12]
+    set float_quotient [expr [expr double($dividend)] / [expr double($divisor)]]
+    set int_quotient [expr int($float_quotient)]
+    set diff [expr $float_quotient - $int_quotient]
+    if {$diff <= $TOLERANCE} {
+        return 1
+    } else {
+        return 0
+    }
+}
     
 #write radial and theta bin output to file 
 proc output_bins {fl  ri rf bins} {
@@ -583,9 +596,7 @@ proc polarDensityBin { config_file_script } {
     source $params(utils)/BinTools.tcl
 
     ;# check to make sure Rmax is evenly divisible by dr.
-    set divisibility_test [expr [expr double($params(Rmax))] % [expr double($params(dr))]]
-    set TOLERANCE [expr 10**-12]
-    if {$divisibility_test >= $TOLERANCE} {
+    if {[test_if_evenly_divisible $params(Rmax) $params(dr)] != 1} {
         error "Rmax must be evenly divisible by dr."
     }
     

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -337,12 +337,11 @@ proc frame_leaflet_assignment {species headname tailname lipidbeads_selstr frame
     } else {
         error "restrict_leaflet_sorter_to_Rmax must be 1 or 0"
     }
-    
     set sel_num [llength [lsort -unique [$sel get resid] ] ]
     set sel_resid_list [lsort -unique [$sel get resid] ]
     set totals {}
     if {$sel_num < 1} {
-        set totals [[list 0 0] [list 0 0]] 
+        set totals [list "lower 0 0" "upper 0 0"] 
     } else {
         #assign leaflets from $frame_i to user2 field of each bead for this species
         foreach sel_resid $sel_resid_list {

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -335,8 +335,7 @@ proc frame_leaflet_assignment {species headname tailname lipidbeads_selstr frame
     } elseif {$restrict_to_Rmax == 0} {
         set sel [ atomselect top "(($species)) and $lipidbeads_selstr"  frame $frame_i]
     } else {
-        puts "restrict_leaflet_sorter_to_Rmax must be 1 or 0."
-        error
+        error "restrict_leaflet_sorter_to_Rmax must be 1 or 0"
     }
     
     set sel_num [llength [lsort -unique [$sel get resid] ] ]

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -329,7 +329,8 @@ proc leaflet_detector {atsel_in head tail frame_i leaflet_sorting_algorithm} {
 ;# Returns the following list : [["lower" lower_leaflet_beads lower_leaflet_lipids] ["upper" upper_leaflet_beads upper_leaflet_lipids]] 
 proc frame_leaflet_assignment {species headname tailname lipidbeads_selstr frame_i frame_f} {
     global params
-    set sel [ atomselect top "(($species)) and $lipidbeads_selstr"  frame $frame_i]
+    set outer_r2 [expr $params(Rmax)**2]
+    set sel [ atomselect top "(($species)) and $lipidbeads_selstr and ((x*x + y*y < $outer_r2))"  frame $frame_i]
     set sel_num [llength [lsort -unique [$sel get resid] ] ]
     set sel_resid_list [lsort -unique [$sel get resid] ]
     set totals {}

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -590,10 +590,9 @@ proc polarDensityBin { config_file_script } {
     ;# a questionable life choice.
     set divisibility_test [expr [expr int([expr $params(Rmax) * 10000])] % [expr int([expr $params(dr) * 10000])]]
     if {$divisibility_test != 0} {
-        puts "Rmax must be evenly divisible by dr."
-        puts "Exiting polarDensityBin early."
-        return
+        error "Rmax must be evenly divisible by dr."
     }
+    
     if {$params(use_qwrap) == 1} {load $params(utils)/qwrap.so}
     set backbone_selstr $params(backbone_selstr) ;#only necessary for backwards compatibility 
     set protein_selstr $params(protein_selstr) ;#only necessary for backwards compatibility 

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -330,7 +330,7 @@ proc leaflet_detector {atsel_in head tail frame_i leaflet_sorting_algorithm} {
 proc frame_leaflet_assignment {species headname tailname lipidbeads_selstr frame_i frame_f} {
     global params
     set outer_r2 [expr $params(Rmax)**2]
-    set sel [ atomselect top "(($species)) and $lipidbeads_selstr and ((x*x + y*y < $outer_r2))"  frame $frame_i]
+    set sel [ atomselect top "(($species)) and $lipidbeads_selstr and same resid as ((x*x + y*y < $outer_r2))"  frame $frame_i]
     set sel_num [llength [lsort -unique [$sel get resid] ] ]
     set sel_resid_list [lsort -unique [$sel get resid] ]
     set totals {}
@@ -487,7 +487,7 @@ proc loop_over_frames {shell species headname tailname lipidbeads_selstr start_f
 proc loop_over_shells {species headname tailname lipidbeads_selstr low_f upp_f low_f_avg upp_f_avg} {
     global params
     set delta_frame [expr ($params(end_frame) - $params(start_frame)) / $params(dt)]
-    for {set ri $params(Rmin)} { $ri<=$params(Rmax)} { set ri [expr $ri + $params(dr)]} {
+    for {set ri $params(Rmin)} { $ri<$params(Rmax)} { set ri [expr $ri + $params(dr)]} {
         #loop over shells
         puts "Now on shell {$ri [expr ${ri}+$params(dr)]}"
         set rf [expr $ri + $params(dr)]
@@ -574,6 +574,12 @@ proc polarDensityBin { config_file_script } {
     global params
     set_parameters $config_file_script
     source $params(utils)/BinTools.tcl
+    set divisibility_test [expr [expr int([expr $params(Rmax) * 10000])] % [expr int([expr $params(dr) * 10000])]]
+    if {$divisibility_test != 0} {
+        puts "Rmax must be evenly divisible by dr."
+        puts "Exiting polarDensityBin early."
+        return
+    }
     if {$params(use_qwrap) == 1} {load $params(utils)/qwrap.so}
     set backbone_selstr $params(backbone_selstr) ;#only necessary for backwards compatibility 
     set protein_selstr $params(protein_selstr) ;#only necessary for backwards compatibility 

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -398,7 +398,7 @@ proc clean_leaflet_assignments {species lipidbeads_selstr} {
 #Return 0 if not evenly divisible.
 proc test_if_evenly_divisible {dividend divisor} {
     set TOLERANCE [expr 10.0**-12]
-    set float_quotient [expr [expr double($dividend)] / [expr double($divisor)]]
+    set float_quotient [expr $dividend / double($divisor)]
     set int_quotient [expr int($float_quotient)]
     set diff [expr $float_quotient - $int_quotient]
     if {$diff <= $TOLERANCE} {

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -574,6 +574,12 @@ proc polarDensityBin { config_file_script } {
     global params
     set_parameters $config_file_script
     source $params(utils)/BinTools.tcl
+
+    ;# check to make sure Rmax is evenly divisible by dr.
+    ;# Cannot ensure that Rmax and dr are both ints, so divisibility_test
+    ;# multiplies both by 10,000 before converting to int as a reasonable
+    ;# precaution. Specifying Rmax and dr to greater than 5 decimal places is
+    ;# a questionable life choice.
     set divisibility_test [expr [expr int([expr $params(Rmax) * 10000])] % [expr int([expr $params(dr) * 10000])]]
     if {$divisibility_test != 0} {
         puts "Rmax must be evenly divisible by dr."


### PR DESCRIPTION
## Description
When running polarDensityBin the leaflet sorter would run on all lipids in the system, even those outside of the zone of analysis. After this PR, the user can select whether leaflet sorting will only occur for lipids within Rmax or for all lipids. 

In the process, we discovered a bug (issue #104). If the user specified an Rmax that was evenly divisible by dr, then polarDensityBin would analyze past Rmax by one shell. If the user specified an Rmax that was not evenly divisible by dr, then polarDensityBin would happily accept that choice without balking (but density enrichment analysis would be affected in the outermost shell downstream). 

We also found that expected density was being measured on start_frame rather than end_frame (issue #107).

We also found a minor error when no lipids are detected within the shell (issue #110).

After this PR, shells will no longer exceed Rmax when Rmax is evenly divisible by dr. Additionally, polarDensityBin will give an error message and quit if Rmax is not evenly divisible by dr. This fix is agnostic to whether the user uses ints or floats in their config file. Expected density will be measured on end_frame.

Implementation of auto-rescaling dr (issue #105) will occur in a future PR

## Usage Changes
- User has access to restrict_leaflet_sorter_to_Rmax parameter (default is 0).
- User will receive an error message if they specify Rmax not evenly divisible by dr.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Leaflet sorting can either sort all lipids or only sort lipids within Rmax
  - [x] If Rmax is evenly divisible by dr, shells will no longer exceed Rmax
  - [x] Expected density measured on end_frame
  - [x] User receives error message f Rmax is not evenly divisible by dr.
  - [x] User receives error message if restrict_leaflet_sorter_to_Rmax is not 1 or 0 (default is 0)
  - [x] Bug fix: empty shell no longer causes error.

## Pre-Review checklist (PR maker)
- [x] Ensure no run-time errors
- [x] Test with variety of Rmax and dr options
- [x] Test with variety of restrict_leaflet_sorter_to_Rmax options
- [x] Run same analysis twice - once prior to change and once after change - and then vimdiff the outputs to ensure they are identical
- [x] Run same analysis twice - once prior to change and once after change - and ensure that resulting delta Gsite is the same at the very end (perform end-to-end testing)
- [x] Include test in the DTA_Testing repo ([here](https://github.com/BranniganLab/DTA_Testing/tree/main/98-leaflet-sorting-should-only-select-lipids-within-zone-of-analysis))

## Review checklist (Reviewer)
- [x] No missed "low-hanging fruit" that would substantially aid readability.
- [x] Any "high-hanging" or "rotten" fruit is added to the issues list.
- [x] I understand what the changes are doing and how
- [x] I understand the motivation for this PR (the PR itself is appropriately documented)

## Status
- [x] Ready for review