### PR TITLE
fixed colorbar getting cut off

### DIFF
--- a/python/preliminaries.ipynb
+++ b/python/preliminaries.ipynb
@@ -160,7 +160,7 @@
     "\n",
     "\n",
     "fig.tight_layout()\n",
-    "plt.savefig(root.joinpath(\"ELIC_enrichments.pdf\"))\n",
+    "plt.savefig(root.joinpath(\"ELIC_enrichments.pdf\"), bbox_inches='tight')\n",
     "plt.show()"
    ]
   },


### PR DESCRIPTION
## Description
This PR fixes a figure issue in the Preliminaries notebook. When plotting the density enrichment heatmap, the colorbar would often be cutoff (see issue #106). This is fixed with a bbox_inches='tight' argument.

## Usage Changes
None

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Make it so that the colorbar doesn't get cutoff in the density heatmap plot

## Review checklist (Reviewer)
- [x] I understand what the changes are doing and how
- [x] I understand the motivation for this PR (the PR itself is appropriately documented)

## Status
- [x] Ready for review