### PR TITLE
126 site outline contains individual bin edges

### DIFF
--- a/python/SymmetricSite.py
+++ b/python/SymmetricSite.py
@@ -27,6 +27,11 @@ class SymmetricSite:
         The name of the Site. Will be inherited from base_site.
     symmetry : int
         The N-fold symmetry desired. I.E. 5 would yield 5 Sites.
+    bin_coords : list of tuples
+        The bins that belong to this site in (r, theta) format. e.g. \
+        [(2, 10), (2, 11), (2, 12)] would correspond to the 11th, 12th, and \
+        13th theta bins in the 3rd radial bin from the origin. Bin coordinates \
+        are zero-indexed by convention.
     get_site_list : list
         The list of constituent Site objects that make up this SymmetricSite.
     site_counts_histogram : numpy ndarray

--- a/python/SymmetricSite.py
+++ b/python/SymmetricSite.py
@@ -94,6 +94,28 @@ class SymmetricSite:
         return self._symmetry
 
     @property
+    def bin_coords(self):
+        """
+        Generate one list of bin coordinate tuples corresponding to all the \
+        bins inside this SymmetricSite. Necessary for outline_site.
+
+        Returns
+        -------
+        bin_coords_list : list of tuples
+            The bins that belong to this SymmetricSite in (r, theta) format. \
+            e.g. [(2, 10), (2, 11), (2, 12)] would correspond to the 11th, \
+            12th, and 13th theta bins (starting at theta=0) in the 3rd radial \
+            bin from the origin. Bin coordinates are zero-indexed by convention.
+
+        """
+        bin_coords_list = []
+        for site in self.get_site_list:
+            site_coords = site.bin_coords
+            for each_bin in site_coords:
+                bin_coords_list.append(each_bin)
+        return bin_coords_list
+
+    @property
     def get_site_list(self):
         """
         Tell me the site_list, but don't let me change the site_list.

--- a/python/plotting.py
+++ b/python/plotting.py
@@ -127,7 +127,7 @@ def _find_edge_in_list(edge, line_list):
 
 def compile_bin_edges(bin_coords, grid_dims):
     """
-    Draw an outline around this bin.
+    Determine the 4 lines that outline this bin.
 
     Parameters
     ----------

--- a/python/plotting.py
+++ b/python/plotting.py
@@ -97,7 +97,6 @@ def isolate_unique_site_edges(bin_coords_list, grid_dims):
                 line_list.pop(index)
             else:
                 line_list.append(edge)
-    print(len(line_list))
     return line_list
 
 

--- a/python/plotting.py
+++ b/python/plotting.py
@@ -55,6 +55,7 @@ def outline_site(ax, site, grid_dims):
 
     """
     assert isinstance(site, (Site, SymmetricSite)), "site must be a Site or SymmetricSite."
+    assert site.bin_coords is not None, "Site must be fully defined first. Please add bin_coords."
     edges = isolate_unique_site_edges(site.bin_coords, grid_dims)
     for edge_tuple in edges:
         r, theta = edge_tuple

--- a/python/plotting.py
+++ b/python/plotting.py
@@ -34,9 +34,9 @@ def make_custom_colormap():
     return my_cmap
 
 
-def outline_site_new(ax, site, grid_dims):
+def outline_site(ax, site, grid_dims):
     """
-    Draw an outline around each bin in this Site.
+    Draw an outline around a Site or around each site in a SymmetricSite.
 
     Parameters
     ----------
@@ -54,26 +54,83 @@ def outline_site_new(ax, site, grid_dims):
         The Axes object you want to draw this on.
 
     """
-    if isinstance(site, Site):
-        for each_bin in site.bin_coords:
-            ax = outline_bin(ax, each_bin, grid_dims)
-    elif isinstance(site, SymmetricSite):
-        for each_site in site.get_site_list:
-            for each_bin in each_site.bin_coords:
-                ax = outline_bin(ax, each_bin, grid_dims)
-    else:
-        Exception("site must be a Site or SymmetricSite.")
+    assert isinstance(site, (Site, SymmetricSite)), "site must be a Site or SymmetricSite."
+    edges = isolate_unique_site_edges(site.bin_coords, grid_dims)
+    for edge_tuple in edges:
+        r, theta = edge_tuple
+        ax.plot(theta, r, color='black', linewidth=1, marker=None)
     return ax
 
 
-def outline_bin(ax, bin_coords, grid_dims):
+def isolate_unique_site_edges(bin_coords_list, grid_dims):
+    """
+    List all of the edges that need to be drawn in order to enclose the site.\
+    In this lattice space, if edges are repeated it means they are internal \
+    edges and should not be drawn at all.
+
+    Parameters
+    ----------
+    bin_coords_list : list or tuples
+        The bins that belong to this site in (r, theta) format. e.g. \
+        [(2, 10), (2, 11), (2, 12)] would correspond to the 11th, 12th, and \
+        13th theta bins in the 3rd radial bin from the origin. Bin coordinates \
+        are zero-indexed by convention.
+        The list of bin.
+    grid_dims : namedtuple
+        Contains dr, number of r bins, dtheta, number of theta bins, and number\
+        of frames contained in file.
+
+    Returns
+    -------
+    line_list : list of tuples
+        The list of exterior bin edges needed in order to draw the site outline.\
+        Each bin edge is a tuple, with each tuple value being an ndarray.
+
+    """
+    line_list = []
+    for coord_pair in bin_coords_list:
+        edges = compile_bin_edges(coord_pair, grid_dims)
+        for edge in edges:
+            assert isinstance(edge, tuple), "edge must be a tuple"
+            index = _find_edge_in_list(edge, line_list)
+            if index != -1:
+                line_list.pop(index)
+            else:
+                line_list.append(edge)
+    print(len(line_list))
+    return line_list
+
+
+def _find_edge_in_list(edge, line_list):
+    """
+    Iterate through list and compare elements. Need to do this manually rather\
+    than with 'in' because list contents are numpy ndarrays.
+
+    Parameters
+    ----------
+    edge : tuple of ndarrays
+        The line you are looking for in line_list.
+    line_list : list of tuples of ndarrays
+        The list of all lines to be potentially drawn.
+
+    Returns
+    -------
+    int
+        The index in line_list at which edge is found.
+
+    """
+    for index in range(len(line_list)):
+        if np.allclose(edge, line_list[index]):
+            return index
+    return -1
+
+
+def compile_bin_edges(bin_coords, grid_dims):
     """
     Draw an outline around this bin.
 
     Parameters
     ----------
-    ax : matplotlib.pyplot Axes object
-        The Axes object you want to draw this on.
     bin_coords : tuple
         The tuple of bin coordinates stored in (r_bin, theta_bin) format.
     grid_dims : namedtuple
@@ -82,19 +139,23 @@ def outline_bin(ax, bin_coords, grid_dims):
 
     Returns
     -------
-    ax : matplotlib.pyplot Axes object
-        The Axes object you want to draw this on.
+    tuple of tuples
+        The four lines corresponding to the bin edges. Each tuple contains two\
+        ndarrays of equal lengths.
 
     """
     assert isinstance(bin_coords, tuple), "bin_coords must be a tuple of bin coordinates."
-    dr, _, dtheta, _, _ = grid_dims
-    start_theta = bin_coords[1] * dtheta
-    end_theta = start_theta + dtheta
-    inner_r = bin_coords[0] * dr
-    outer_r = inner_r + dr
+    start_theta = bin_coords[1] * grid_dims.dtheta
+    end_theta = start_theta + grid_dims.dtheta
+    inner_r = bin_coords[0] * grid_dims.dr
+    outer_r = inner_r + grid_dims.dr
     theta_range = np.linspace(start_theta, end_theta, 100)
-    ax.fill_between(theta_range, inner_r, outer_r, facecolor=(0, 0, 0, 0), edgecolor='k')
-    return ax
+    r_range = np.linspace(inner_r, outer_r, 100)
+    line1 = (np.linspace(inner_r, inner_r, 100), theta_range)
+    line2 = (np.linspace(outer_r, outer_r, 100), theta_range)
+    line3 = (r_range, np.linspace(start_theta, start_theta, 100))
+    line4 = (r_range, np.linspace(end_theta, end_theta, 100))
+    return (line1, line2, line3, line4)
 
 
 def create_heatmap_figure_and_axes(lipids, cmap, v_vals, figwidth, figheight, helices):


### PR DESCRIPTION
## Description
In the current state, plotting.outline_site would outline each bin individually rather than outline the entire site. This has been fixed. 

Please note that there is no site definition checking in place, so the user is free to define non-contiguous sites, define sites outside of the zone of analysis, define overlapping sites, etc. This is addressed by issue #109 and a future PR.

## Usage Changes
SymmetricSite now has a bin_coords property, just like Site.

## Pre-Review checklist (PR maker)
- [x] New functions are documented
- [x] New configuration parameters are documented (Usage changes above)
- [x] Test notebook created and put in DTA_Testing repo 
- [x] Variety of site shapes tested

## Review checklist (Reviewer)
- [x] New functions are documented 
- [x] New functions/variables are named appropriately
- [x] No missed "low-hanging fruit" that would substantially aid readability.
- [x] Any "high-hanging" or "rotten" fruit is added to the issues list.
- [x] I understand what the changes are doing and how
- [x] I understand the motivation for this PR (the PR itself is appropriately documented)
- [x] I have looked at the test notebook in DTA_Testing and played around with it

## Status
- [x] Ready for review