### PR TITLE
128a generate titration curves from deltag

### DIFF
--- a/python/plotting.py
+++ b/python/plotting.py
@@ -154,6 +154,10 @@ def compile_bin_edges(bin_coords, grid_dims):
     r_range = np.linspace(inner_r, outer_r, 100)
     line1 = (np.linspace(inner_r, inner_r, 100), theta_range)
     line2 = (np.linspace(outer_r, outer_r, 100), theta_range)
+    if np.allclose(start_theta, 2 * np.pi):
+        start_theta = 0
+    if np.allclose(end_theta, 2 * np.pi):
+        end_theta = 0
     line3 = (r_range, np.linspace(start_theta, start_theta, 100))
     line4 = (r_range, np.linspace(end_theta, end_theta, 100))
     return (line1, line2, line3, line4)


### PR DESCRIPTION
## Description
Adds a plot_titration_curve function. Also, outline_site will no longer draw a line at theta=0 when it's not supposed to.

## Pre-Review checklist (PR maker)
- [x] New functions are documented
- [x] Testing notebook created
- [x] nb added to DTA_Testing repo
- [x] sanity checks performed

## Review checklist (Reviewer)
- [x] New functions are documented 
- [x] New functions/variables are named appropriately
- [x] No missed "low-hanging fruit" that would substantially aid readability.
- [x] Any "high-hanging" or "rotten" fruit is added to the issues list.
- [x] I understand what the changes are doing and how
- [x] I understand the motivation for this PR (the PR itself is appropriately documented)
- [x] I have played around with the notebook in DTA_Testing and found nothing suspect

## Status
- [x] Ready for review