### PR TITLE
Remove axis spines from heatmap plots

### DIFF
--- a/python/plotting.py
+++ b/python/plotting.py
@@ -296,6 +296,7 @@ def plot_heatmap(ax, data, grid_dims, cmap, v_vals):
     ax.pcolormesh(theta, radius, data, cmap=cmap, norm=norm, zorder=0, edgecolors='face', linewidth=0)
     ax.set_xticklabels([])
     ax.set_yticklabels([])
+    ax.spines['polar'].set_visible(False)
     return ax
 
 

--- a/python/plotting.py
+++ b/python/plotting.py
@@ -410,7 +410,7 @@ class MidpointNormalize(Normalize):
         return np.ma.masked_array(np.interp(value, x, y), np.isnan(value))
 
 
-def plot_helices(helices, colorbychain, ax, markersize=3, sub=["tab:blue", "tab:cyan", "tab:green", "tab:purple", "tab:brown", "tab:olive"]):
+def plot_helices(helices, colorbychain, ax, markersize=3, sub=["tab:blue", "tab:cyan", "tab:green", "tab:purple", "tab:brown", "tab:olive", "tab:orange"]):
     """
     Plot helices on a polar plot.
 


### PR DESCRIPTION
## Description
Axis spines no longer present in heatmap plots. (They had been showing up in all but the last heatmap, making the plots look funny). 

Additionally, there is now an extra default color added to helix plotting so that GPCRs work by default.


## Review checklist (Reviewer)
- [x] I understand what the changes are doing and how
- [x] I understand the motivation for this PR (the PR itself is appropriately documented)

## Status
- [x] Ready for review