### PR TITLE
99 do get countstcl needs way to select subsection of lipid

### DIFF
--- a/accessible_area/do_get_counts.tcl
+++ b/accessible_area/do_get_counts.tcl
@@ -38,7 +38,7 @@ set fieldid "user2"
 if {$ASSIGN_LEAFLETS == 1} {
 	foreach atsel $atsels {
 		puts "assigning leaflets for $atsel with leaflet sorter $leaflet_sorter_option"
-		run_leaflet_sorter $species $leaflet_sorter_option $stride
+		run_leaflet_sorter $atsel $leaflet_sorter_option $stride
 	}
 }
 
@@ -67,7 +67,7 @@ if {$GET_COUNTS == 1} {
 				set ymin $YMIN
 				while {$ymin < $YMAX} {
 					puts "Running at $xmin $ymin leaflet $leaflet_id"
-					set data [get_count_with_area $area $xmin $ymin "(${species}) and $fieldid $leaflet_id" top 0 -1 $stride]
+					set data [get_count_with_area $area $xmin $ymin "(${atsel}) and $fieldid $leaflet_id" top 0 -1 $stride]
 					puts $outfile $data
 					set ymin [expr $ymin + $step]
 				}

--- a/accessible_area/do_get_counts.tcl
+++ b/accessible_area/do_get_counts.tcl
@@ -4,84 +4,76 @@ set UTILS "$help_me_dir/../TCL/helpers"
 set USE_QWRAP 0
 source $help_me_dir/../TCL/polarDensity_for_DTA.tcl
 
-proc use_old_sorter {species {stride 1}} {
-	set all_lipids [atomselect top "resname $species"]
+proc run_leaflet_sorter {atsel sorter_num {stride 1}} {
+	set all_lipids [atomselect top $atsel]
 	set resids [lsort -integer -unique [$all_lipids get resid]]
 	set nframes [molinfo top get numframes]
-	foreach resid $resids {
-		if {[expr $resid%100] == 0} { puts "on resid $resid at [clock seconds]" }
-		set seltext "resname $species and resid $resid"
-		for {set frm 0} {$frm < $nframes} {incr frm $stride} {
-			leaflet_sorter_3 $seltext $frm
-		}
-	}
-}
-
-proc assign_all_frames {species {stride 1}} {
-	set nframes [molinfo top get numframes]
-	set all_lipids [atomselect top "resname $species"]
-	set resids [lsort -integer -unique [$all_lipids get resid]]
 	$all_lipids delete
 	foreach resid $resids {
 		if {[expr $resid%100] == 0} { puts "on resid $resid at [clock seconds]" }
+		set seltext "$atsel and resid $resid"
 		for {set frm 0} {$frm < $nframes} {incr frm $stride} {
-			leaflet_sorter_1 "resname $species and resid $resid" $frm
+			if {$sorter_num == 1} {
+				leaflet_sorter_1 $seltext $frm	
+			} elseif {$sorter_num == 3} {
+				leaflet_sorter_3 $seltext $frm	
+			}
+			
 		}
 	}
 }
 
+set atsels [list "resname CHOL"]
+set names [list "CHOL"]
 
 set ASSIGN_LEAFLETS 1
+set leaflet_sorter_option 1
 set GET_COUNTS 1
-set spp [list "DPPC"]
-set area 52
+
+set area 85
 set stride 10
 set fieldid "user2"
 
-set step [expr $area**(0.5)]
-
-set all [atomselect top "name PO4"]
-set XMIN [lindex [measure minmax $all] 0 0]
-set YMIN [lindex [measure minmax $all] 0 1]
-set XMAX [lindex [measure minmax $all] 1 0]
-set YMAX [lindex [measure minmax $all] 1 1]
-
-set XMIN [expr $XMIN+$step]
-set YMIN [expr $YMIN+$step]
-set XMAX [expr $XMAX-$step]
-set YMAX [expr $YMAX-$step]
 
 if {$ASSIGN_LEAFLETS == 1} {
-	set fieldid "user2"
-	foreach species $spp {
-		puts "assigning leaflets of $species"
-		#use_old_sorter $species $stride
-		assign_all_frames $species $stride
+	foreach atsel $atsels {
+		puts "assigning leaflets for $atsel with leaflet sorter $leaflet_sorter_option"
+		run_leaflet_sorter $species $leaflet_sorter_option $stride
 	}
 }
 
-set box_width [lindex [measure minmax $all] 1 0]
-$all delete
 
-foreach species $spp {
-	if {$GET_COUNTS == 1} {
-		set outfile [open "${species}_counts_${area}.out" w]   
+if {$GET_COUNTS == 1} {
+	set all [atomselect top "name PO4"]
+	set minmax [measure minmax $all]
+	$all delete
 
-		foreach field {1 '-1'} {
+	set XMIN [lindex $minmax 0 0]
+	set YMIN [lindex $minmax 0 1]
+	set XMAX [lindex $minmax 1 0]
+	set YMAX [lindex $minmax 1 1]
+
+	set step [expr $area**(0.5)]
+	set XMIN [expr $XMIN+$step]
+	set YMIN [expr $YMIN+$step]
+	set XMAX [expr $XMAX-$step]
+	set YMAX [expr $YMAX-$step]
+
+	foreach atsel $atsels name $names {
+		set outfile [open "${name}_counts_${area}.out" w]   
+		foreach leaflet_id {1 '-1'} {
 			set xmin $XMIN
 			while {$xmin < $XMAX} {
 				set ymin $YMIN
 				while {$ymin < $YMAX} {
-					puts "Running at $xmin $ymin leaflet $field"
-					set data [get_count_with_area $area $xmin $ymin "resname $species and $fieldid $field" top 0 -1 $stride]
+					puts "Running at $xmin $ymin leaflet $leaflet_id"
+					set data [get_count_with_area $area $xmin $ymin "(${species}) and $fieldid $leaflet_id" top 0 -1 $stride]
 					puts $outfile $data
-
 					set ymin [expr $ymin + $step]
 				}
 				set xmin [expr $xmin + $step]
 			}
 		}
-
 		close $outfile
 	}
 }

--- a/accessible_area/do_get_counts.tcl
+++ b/accessible_area/do_get_counts.tcl
@@ -1,8 +1,7 @@
 variable help_me_dir [file dirname [file normalize [info script]]]
 source $help_me_dir/get_counts.tcl
-set UTILS "$help_me_dir/../TCL/helpers"
-set USE_QWRAP 0
 source $help_me_dir/../TCL/polarDensity_for_DTA.tcl
+
 
 proc run_leaflet_sorter {atsel sorter_num {stride 1}} {
 	set all_lipids [atomselect top $atsel]
@@ -22,6 +21,7 @@ proc run_leaflet_sorter {atsel sorter_num {stride 1}} {
 		}
 	}
 }
+
 
 set atsels [list "resname CHOL"]
 set names [list "CHOL"]


### PR DESCRIPTION
## Description
One of DTA's strengths is that it can analyze parts of a lipid (individual tails, say) or combine multiple parts of multiple lipids (all the polyunsaturated tails in the system, say) in one analysis. Currently, do_get_counts.tcl is hardcoded to accept only a lipid species resname. This has been changed so that it accepts atomselection text instead, thus facilitating the aforementioned analyses. In the process I have removed duplicate code, renamed confusing variable names, and linted/tidied.

## Usage Changes
The user now specifies a list of atomselections (rather than resnames), a list of names that correspond to those atomselections, and which leaflet sorter they would like to use (currently 1 or 3). They no longer specify whether or not to use QWRAP, as this was never implemented. $spp is now called $atsels for clarity.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] Some variable names renamed for clarity
  - [ ] two leaflet sorter procs condensed into one
  - [ ] general tidying of code
  - [ ] user specifies atomselections and names rather than $spp list
  - [ ] resname is no longer hardcoded

## Pre-Review checklist (PR maker)
- [ ] New procs run without errors
- [ ] New proc compared against old proc and results match (saved in DTA_Testing repo)
- [ ] New functions are documented
- [ ] New configuration parameters are documented (Usage changes above)

## Review checklist (Reviewer)
- [ ] [Optional] diff the old results against the new results in DTA_Testing repo
- [ ] No missed "low-hanging fruit" that would substantially aid readability.
- [ ] Any "high-hanging" or "rotten" fruit is added to the issues list.
- [ ] I understand what the changes are doing and how
- [ ] I understand the motivation for this PR (the PR itself is appropriately documented)

## Status
- [ ] Ready for review