### PR TITLE
142 loop over lipids has unused variables

### DIFF
--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -443,11 +443,8 @@ proc theta_histogram {singleFrame_lower singleFrame_upper } {
 proc loop_over_lipids {shell species headname tailname lipidbeads_selstr frm} {
     global params
     set indexs [$shell get index]
-    set resids [$shell get resid]
-    set nShell [$shell num]
     set theta_high_out [list]
     set theta_low_out [list]
-    set resd_old 0
     set leaflet 0
     foreach indx $indexs {
         #loop over lipids in the shell

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -448,8 +448,8 @@ proc loop_over_lipids {shell species headname tailname lipidbeads_selstr frm} {
     set leaflet 0
     foreach indx $indexs {
         #loop over lipids in the shell
-        set a "($species) and index $indx"
-        set thislipid [atomselect top $a frame $frm]
+        set atsel "($species) and index $indx"
+        set thislipid [atomselect top $atsel frame $frm]
         set x [$thislipid get x]
         set y [$thislipid get y]
         set leaflet [$thislipid get user2]

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -449,19 +449,18 @@ proc loop_over_lipids {shell species headname tailname lipidbeads_selstr frm} {
     set theta_low_out [list]
     set resd_old 0
     set leaflet 0
-    foreach indx $indexs resd $resids {
+    foreach indx $indexs {
         #loop over lipids in the shell
-        set a "($species and index $indx)"
-        set b "(resid $resd and $species and $lipidbeads_selstr)" 
+        set a "($species) and index $indx"
         set thislipid [atomselect top $a frame $frm]
         set x [$thislipid get x]
         set y [$thislipid get y]
-        set leaflet [$thislipid get user2] ;
+        set leaflet [$thislipid get user2]
         set theta [get_theta $x $y]
         set ti [expr int($theta/$params(dtheta))] 
         if {$leaflet > 0} {
             lappend theta_high_out $ti
-        } elseif {$leaflet <0} {
+        } elseif {$leaflet < 0} {
             lappend theta_low_out $ti
         } else {
             puts "WARNING: lipid $resd did not get assigned a leaflet for frame $frm"

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -448,7 +448,7 @@ proc loop_over_lipids {shell species headname tailname lipidbeads_selstr frm} {
     set leaflet 0
     foreach indx $indexs {
         #loop over lipids in the shell
-        set atsel "($species) and index $indx"
+        set atsel "($species and index $indx)"
         set thislipid [atomselect top $atsel frame $frm]
         set x [$thislipid get x]
         set y [$thislipid get y]


### PR DESCRIPTION
## Description
Loop_over_shells had several unused variables. I have linted the proc.

## Usage Changes
None.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] Deleted unused variables: $resids, $nShell, $resd_old, $b
  - [ ] $a is renamed $atsel

## Pre-Review checklist (PR maker)
- [ ] Confirm that this runs without errors

## Review checklist (Reviewer)
- [ ] New functions/variables are named appropriately
- [ ] No missed "low-hanging fruit" that would substantially aid readability.
- [ ] Any "high-hanging" or "rotten" fruit is added to the issues list.
- [ ] I understand what the changes are doing and how
- [ ] I understand the motivation for this PR (the PR itself is appropriately documented)

## Status
- [ ] Ready for review