### PR TITLE
138 moved warnings to correct level

### DIFF
--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -321,7 +321,8 @@ proc leaflet_detector {atsel_in head tail frame_i leaflet_sorting_algorithm} {
     } elseif { $leaflet_sorting_algorithm == 3 } {
         leaflet_sorter_3 $atsel_in $frame_i
     } else { 
-        puts "Option $leaflet_sorting_algorithm not recognized as a leaflet sorting option.  Defaulting to option 1." 
+        puts "Option $leaflet_sorting_algorithm not recognized as a leaflet sorting option. Defaulting to option 1."
+        leaflet_sorter_1 $atsel_in $frame_i
     }
 }
 

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -373,7 +373,7 @@ proc trajectory_leaflet_assignment {species headname tailname lipidbeads_selstr}
     global params
     set num_reassignments 0
     if {[lsearch -integer -exact "0 1 2 3" $params(leaflet_sorting_algorithm)] != -1} {
-        puts "Option $leaflet_sorting_algorithm not recognized as a leaflet sorting option. Defaulting to option 1."
+        puts "Option $params(leaflet_sorting_algorithm) not recognized as a leaflet sorting option. Defaulting to option 1."
     } elseif {$params(leaflet_sorting_algorithm) == 2} {
         if {$params(leaflet_sorter_2_reference_sel) eq "none"} {
                 puts "No reference selection provided for leaflet sorter 2."

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -372,7 +372,7 @@ proc frame_leaflet_assignment {species headname tailname lipidbeads_selstr frame
 proc trajectory_leaflet_assignment {species headname tailname lipidbeads_selstr} { 
     global params
     set num_reassignments 0
-    if {[lsearch -integer -exact "0 1 2 3" $params(leaflet_sorting_algorithm)] != -1} {
+    if {[lsearch -integer -exact "0 1 2 3" $params(leaflet_sorting_algorithm)] == -1} {
         puts "Option $params(leaflet_sorting_algorithm) not recognized as a leaflet sorting option. Defaulting to option 1."
     } elseif {$params(leaflet_sorting_algorithm) == 2} {
         if {$params(leaflet_sorter_2_reference_sel) eq "none"} {
@@ -606,7 +606,6 @@ proc polarDensityBin { config_file_script } {
     if {[test_if_evenly_divisible $params(Rmax) $params(dr)] != 1} {
         error "Rmax must be evenly divisible by dr."
     }
-    
     if {$params(use_qwrap) == 1} {load $params(utils)/qwrap.so}
     set backbone_selstr $params(backbone_selstr) ;#only necessary for backwards compatibility 
     set protein_selstr $params(protein_selstr) ;#only necessary for backwards compatibility 

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -372,7 +372,7 @@ proc frame_leaflet_assignment {species headname tailname lipidbeads_selstr frame
 proc trajectory_leaflet_assignment {species headname tailname lipidbeads_selstr} { 
     global params
     set num_reassignments 0
-    if {[lsearch -integer -exact "0 1 2 3" $params(leaflet_sorting_algorithm)] == -1} {
+    if {[lsearch -exact "0 1 2 3" $params(leaflet_sorting_algorithm)] == -1} {
         puts "Option $params(leaflet_sorting_algorithm) not recognized as a leaflet sorting option. Defaulting to option 1."
     } elseif {$params(leaflet_sorting_algorithm) == 2} {
         if {$params(leaflet_sorter_2_reference_sel) eq "none"} {

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -317,6 +317,7 @@ proc leaflet_detector {atsel_in head tail frame_i leaflet_sorting_algorithm} {
     } elseif { $leaflet_sorting_algorithm == 3 } {
         leaflet_sorter_3 $atsel_in $frame_i
     } else { 
+        #default
         leaflet_sorter_1 $atsel_in $frame_i
     }
 }

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -254,8 +254,6 @@ proc leaflet_sorter_1 {atsel_in frame_i} {
 ;#originally by Jahmal Ennis, designed for cholesterol 
 proc leaflet_sorter_2 {atsel_in refsel_in frame_i} { 
     if {$refsel_in eq "none"} {
-        puts "No reference selection provided for leaflet sorter 2."
-        puts "Defaulting to z=0 as the reference height to sort by."
         set refsel_com_z 0
     } else {
         set refsel [atomselect top "$refsel_in" frame $frame_i]
@@ -315,6 +313,10 @@ proc leaflet_detector {atsel_in head tail frame_i leaflet_sorting_algorithm} {
     } elseif { $leaflet_sorting_algorithm == 1 } {
         leaflet_sorter_1 $atsel_in $frame_i
     } elseif { $leaflet_sorting_algorithm == 2 } {
+        if {$params(leaflet_sorter_2_reference_sel) eq "none"} {
+            puts "No reference selection provided for leaflet sorter 2."
+            puts "Defaulting to z=0 as the reference height to sort by."
+        }
         leaflet_sorter_2 $atsel_in $params(leaflet_sorter_2_reference_sel) $frame_i
     } elseif { $leaflet_sorting_algorithm == 3 } {
         leaflet_sorter_3 $atsel_in $frame_i

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -313,15 +313,10 @@ proc leaflet_detector {atsel_in head tail frame_i leaflet_sorting_algorithm} {
     } elseif { $leaflet_sorting_algorithm == 1 } {
         leaflet_sorter_1 $atsel_in $frame_i
     } elseif { $leaflet_sorting_algorithm == 2 } {
-        if {$params(leaflet_sorter_2_reference_sel) eq "none"} {
-            puts "No reference selection provided for leaflet sorter 2."
-            puts "Defaulting to z=0 as the reference height to sort by."
-        }
         leaflet_sorter_2 $atsel_in $params(leaflet_sorter_2_reference_sel) $frame_i
     } elseif { $leaflet_sorting_algorithm == 3 } {
         leaflet_sorter_3 $atsel_in $frame_i
     } else { 
-        puts "Option $leaflet_sorting_algorithm not recognized as a leaflet sorting option. Defaulting to option 1."
         leaflet_sorter_1 $atsel_in $frame_i
     }
 }
@@ -376,6 +371,14 @@ proc frame_leaflet_assignment {species headname tailname lipidbeads_selstr frame
 proc trajectory_leaflet_assignment {species headname tailname lipidbeads_selstr} { 
     global params
     set num_reassignments 0
+    if {[lsearch -integer -exact "0 1 2 3" $params(leaflet_sorting_algorithm)] != -1} {
+        puts "Option $leaflet_sorting_algorithm not recognized as a leaflet sorting option. Defaulting to option 1."
+    } elseif {$params(leaflet_sorting_algorithm) == 2} {
+        if {$params(leaflet_sorter_2_reference_sel) eq "none"} {
+                puts "No reference selection provided for leaflet sorter 2."
+                puts "Defaulting to z=0 as the reference height to sort by."
+        }
+    }
     for {set update_frame $params(start_frame)} {$update_frame < $params(end_frame)} {incr update_frame $params(dt)} {
         frame_leaflet_assignment $species $headname $tailname $lipidbeads_selstr $update_frame [expr $update_frame + $params(dt)] $params(restrict_leaflet_sorter_to_Rmax)
         incr num_reassignments


### PR DESCRIPTION
## Description
Leaflet_sorter_2 can either take a reference selection to calculate its height cutoff, or it will default to z=0. The warning that it was defaulting to 0 would display every time leaflet_sorter_2 was invoked IE once for every lipid in the selection area. This was overwhelming and unhelpful. It now displays once at the beginning, which is both whelming and helpful.

Also: in the event that the leaflet sorter option supplied by the user was unrecognized, the code promised to default to leaflet_sorter_1 but then never kept its promise. It now actually invokes leaflet_sorter_1. It also only offers this warning once, as opposed to on every single lipid.

## Usage Changes
No parameter changes.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Warnings moved to correct level
  - [x] leaflet_sorter_1 now runs in the event $leaflet_sorting_algorithm is unrecognized

## Pre-Review checklist (PR maker)
- [x] Run test system with leaflet_sorter_2, once with reference set to 'none' and once with actual reference
- [x] Run test system with leaflet_sorting_algorithm set to something unrecognizable
- [x] Confirm warnings work as expected

## Review checklist (Reviewer)
- [x] I understand what the changes are doing and how
- [x] I understand the motivation for this PR (the PR itself is appropriately documented)

## Status
- [x] Ready for review