### PR TITLE
145 polardensitybin should take atomselection text rather than resnames only

### DIFF
--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -294,7 +294,7 @@ proc leaflet_detector {atsel_in head tail frame_i leaflet_sorting_algorithm} {
 }
 
 
-;# Calculates the total number of lipids and beads of the given species in each leaflet 
+;# Calculates the total number of lipids and beads of the given selection in each leaflet 
 ;# Assigns the leaflet to user2 
 ;# Returns the following list : [["lower" lower_leaflet_beads lower_leaflet_lipids] ["upper" upper_leaflet_beads upper_leaflet_lipids]] 
 proc frame_leaflet_assignment {atseltext headname tailname frame_i frame_f {restrict_to_Rmax 0}} {
@@ -313,7 +313,7 @@ proc frame_leaflet_assignment {atseltext headname tailname frame_i frame_f {rest
     if {$sel_num < 1} {
         set totals [list "lower 0 0" "upper 0 0"] 
     } else {
-        #assign leaflets from $frame_i to user2 field of each bead for this species
+        #assign leaflets from $frame_i to user2 field of each bead for this selection
         foreach sel_resid $sel_resid_list {
             set selstring "(${atseltext}) and (resid $sel_resid)"
             set leaflet [leaflet_detector $selstring $headname $tailname $frame_i $params(leaflet_sorting_algorithm)]
@@ -327,7 +327,7 @@ proc frame_leaflet_assignment {atseltext headname tailname frame_i frame_f {rest
         }
         #count the number of lipids and the number of beads in each leaflet
         foreach leaf [list  "(user2<0)" "(user2>0)"] txtstr [list "lower" "upper"] {
-            set leaf_sel [ atomselect top "(${species} and $leaf)"  frame $frame_i]
+            set leaf_sel [ atomselect top "(${atseltext}) and $leaf"  frame $frame_i]
             set num_beads [$leaf_sel num]
             set num_lipids [llength [lsort -unique [$leaf_sel get resid] ]]
             lappend totals [list $txtstr $num_beads $num_lipids]
@@ -338,7 +338,7 @@ proc frame_leaflet_assignment {atseltext headname tailname frame_i frame_f {rest
     return $totals
 }
 
-;# Calculates the total number of lipids and beads of the given species in each leaflet 
+;# Calculates the total number of lipids and beads of the given selection in each leaflet 
 ;# Returns the following list : [["lower" lower_leaflet_beads lower_leaflet_lipids] ["upper" upper_leaflet_beads upper_leaflet_lipids]] 
 proc trajectory_leaflet_assignment {atseltext headname tailname} { 
     global params
@@ -559,7 +559,7 @@ proc set_parameters { config_file_script } {
 ### polarDensity Function ###
 
 
-;#The main function that initializes, constructs the densities for each lipid species, and outputs to file. 
+;#The main function that initializes, constructs the densities for each lipid selection, and outputs to file. 
 
 proc polarDensityBin { config_file_script } { 
     ;#read parameters

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -616,9 +616,9 @@ proc polarDensityBin { config_file_script } {
             set expected_beads [lindex $leaf_total 1]
             set expected_lipids [lindex $leaf_total 2]
             set expected_bead_density [expr 1.0 * $expected_beads/$area]
-                puts "#Lipid selection $stem in $leaflet_str leaflet: ${expected_lipids} molecules, Num beads : ${expected_beads} beads,  Average Area : [format {%0.0f} $area] A^2, Expected Bead Density : [format {%0.5f} [expr $expected_bead_density]]/A^2, dr*dtheta : [format {%0.5f} [expr $params(dr)*[DtoR $params(dtheta)]]] "
-                puts $lu "#Lipid selection $stem in $leaflet_str leaflet: ${expected_lipids} molecules, Num beads : ${expected_beads} beads,  Average Area : [format {%0.0f} $area] A^2, Expected Bead Density : [format {%0.5f} [expr $expected_bead_density]]/A^2, dr*dtheta : [format {%0.5f} [expr $params(dr)*[DtoR $params(dtheta)]]] "
-                puts $avgfile "#Lipid selection $stem in $leaflet_str leaflet: ${expected_lipids} molecules, Num beads : ${expected_beads} beads,  Average Area : [format {%0.0f} $area] A^2, Expected Bead Density : [format {%0.5f} [expr $expected_bead_density]]/A^2, dr*dtheta : [format {%0.5f} [expr $params(dr)*[DtoR $params(dtheta)]]] "
+                puts "#Selection name $stem in $leaflet_str leaflet: ${expected_lipids} molecules, Num beads : ${expected_beads} beads,  Average Area : [format {%0.0f} $area] A^2, Expected Bead Density : [format {%0.5f} [expr $expected_bead_density]]/A^2, dr*dtheta : [format {%0.5f} [expr $params(dr)*[DtoR $params(dtheta)]]] "
+                puts $lu "#Selection name $stem in $leaflet_str leaflet: ${expected_lipids} molecules, Num beads : ${expected_beads} beads,  Average Area : [format {%0.0f} $area] A^2, Expected Bead Density : [format {%0.5f} [expr $expected_bead_density]]/A^2, dr*dtheta : [format {%0.5f} [expr $params(dr)*[DtoR $params(dtheta)]]] "
+                puts $avgfile "#Selection name $stem in $leaflet_str leaflet: ${expected_lipids} molecules, Num beads : ${expected_beads} beads,  Average Area : [format {%0.0f} $area] A^2, Expected Bead Density : [format {%0.5f} [expr $expected_bead_density]]/A^2, dr*dtheta : [format {%0.5f} [expr $params(dr)*[DtoR $params(dtheta)]]] "
         }
         puts "Processing frames, starting at frame $params(start_frame) and ending at frame $params(end_frame)."
         trajectory_leaflet_assignment $atseltext $headname $tailname   

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -514,7 +514,7 @@ proc set_parameters { config_file_script } {
         start_frame 0  
         backbone_selstr "name BB" 
         protein_selstr "name BB SC1 to SC4"
-        atomsels {"POPG"}
+        atomsels {"resname POPG"}
         headnames {"PO4"}
         tailnames {"C4"}
         chainlist {A B C D E}

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -528,7 +528,7 @@ proc set_parameters { config_file_script } {
         dr 5 
         Ntheta 50
         restrict_leaflet_sorter_to_Rmax 0
-        names "none"
+        filenames "none"
     }
     set nframes [molinfo top get numframes] 
     array set params [list end_frame $nframes]
@@ -577,7 +577,7 @@ proc polarDensityBin { config_file_script } {
     set backbone_selstr $params(backbone_selstr) ;#only necessary for backwards compatibility 
     set protein_selstr $params(protein_selstr) ;#only necessary for backwards compatibility 
     source $params(helix_assignment_script)
-    foreach atseltext $params(atomsels) name $params(names) headname $params(headnames) tailname $params(tailnames) {
+    foreach atseltext $params(atomsels) name $params(filenames) headname $params(headnames) tailname $params(tailnames) {
         ;# make sure the atomselection exists
         set sel [atomselect top "$atseltext"]
         set sel_num [$sel num]

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -528,7 +528,7 @@ proc set_parameters { config_file_script } {
         dr 5 
         Ntheta 50
         restrict_leaflet_sorter_to_Rmax 0
-        filenames {"POPG"}
+        filename_stems {"POPG"}
     }
     set nframes [molinfo top get numframes] 
     array set params [list end_frame $nframes]
@@ -577,7 +577,7 @@ proc polarDensityBin { config_file_script } {
     set backbone_selstr $params(backbone_selstr) ;#only necessary for backwards compatibility 
     set protein_selstr $params(protein_selstr) ;#only necessary for backwards compatibility 
     source $params(helix_assignment_script)
-    foreach atseltext $params(atomsels) name $params(filenames) headname $params(headnames) tailname $params(tailnames) {
+    foreach atseltext $params(atomsels) stem $params(filename_stems) headname $params(headnames) tailname $params(tailnames) {
         ;# make sure the atomselection exists
         set sel [atomselect top "$atseltext"]
         set sel_num [$sel num]
@@ -607,10 +607,10 @@ proc polarDensityBin { config_file_script } {
         }
 
         puts "Atomselection:\t$atseltext"
-        set low_f [open "${name}.low.dat" w]
-        set upp_f [open "${name}.upp.dat" w]
-        set low_f_avg [open "${name}.low.avg.dat" w]
-        set upp_f_avg [open "${name}.upp.avg.dat" w]
+        set low_f [open "${stem}.low.dat" w]
+        set upp_f [open "${stem}.upp.dat" w]
+        set low_f_avg [open "${stem}.low.avg.dat" w]
+        set upp_f_avg [open "${stem}.upp.avg.dat" w]
         set totals [frame_leaflet_assignment $atseltext $headname $tailname $params(end_frame) $params(end_frame)]        
         
         foreach lu [list $low_f $upp_f] avgfile [list $low_f_avg $upp_f_avg] leaf_total $totals {
@@ -618,9 +618,9 @@ proc polarDensityBin { config_file_script } {
             set expected_beads [lindex $leaf_total 1]
             set expected_lipids [lindex $leaf_total 2]
             set expected_bead_density [expr 1.0 * $expected_beads/$area]
-                puts "#Lipid atsel $name in $leaflet_str leaflet: ${expected_lipids} molecules, Num beads : ${expected_beads} beads,  Average Area : [format {%0.0f} $area] A^2, Expected Bead Density : [format {%0.5f} [expr $expected_bead_density]]/A^2, dr*dtheta : [format {%0.5f} [expr $params(dr)*[DtoR $params(dtheta)]]] "
-                puts $lu "#Lipid atsel $name in $leaflet_str leaflet: ${expected_lipids} molecules, Num beads : ${expected_beads} beads,  Average Area : [format {%0.0f} $area] A^2, Expected Bead Density : [format {%0.5f} [expr $expected_bead_density]]/A^2, dr*dtheta : [format {%0.5f} [expr $params(dr)*[DtoR $params(dtheta)]]] "
-                puts $avgfile "#Lipid atsel $name in $leaflet_str leaflet: ${expected_lipids} molecules, Num beads : ${expected_beads} beads,  Average Area : [format {%0.0f} $area] A^2, Expected Bead Density : [format {%0.5f} [expr $expected_bead_density]]/A^2, dr*dtheta : [format {%0.5f} [expr $params(dr)*[DtoR $params(dtheta)]]] "
+                puts "#Lipid selection $stem in $leaflet_str leaflet: ${expected_lipids} molecules, Num beads : ${expected_beads} beads,  Average Area : [format {%0.0f} $area] A^2, Expected Bead Density : [format {%0.5f} [expr $expected_bead_density]]/A^2, dr*dtheta : [format {%0.5f} [expr $params(dr)*[DtoR $params(dtheta)]]] "
+                puts $lu "#Lipid selection $stem in $leaflet_str leaflet: ${expected_lipids} molecules, Num beads : ${expected_beads} beads,  Average Area : [format {%0.0f} $area] A^2, Expected Bead Density : [format {%0.5f} [expr $expected_bead_density]]/A^2, dr*dtheta : [format {%0.5f} [expr $params(dr)*[DtoR $params(dtheta)]]] "
+                puts $avgfile "#Lipid selection $stem in $leaflet_str leaflet: ${expected_lipids} molecules, Num beads : ${expected_beads} beads,  Average Area : [format {%0.0f} $area] A^2, Expected Bead Density : [format {%0.5f} [expr $expected_bead_density]]/A^2, dr*dtheta : [format {%0.5f} [expr $params(dr)*[DtoR $params(dtheta)]]] "
         }
         puts "Processing frames, starting at frame $params(start_frame) and ending at frame $params(end_frame)."
         trajectory_leaflet_assignment $atseltext $headname $tailname   

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -128,35 +128,6 @@ proc output_helix_centers {{a ""} } {
     }
 }
 
-;#determines the average acyl chain length for a given species 
-;#usage unclear
-proc avg_acyl_chain_len {species acylchain_selstr} {
-    set acyl_num 0
-    set sel [atomselect top "$species"]
-    set sel_resname [lsort -unique [$sel get resname]]
-    #set sel_num [llength [lsort -unique [$sel get resname]]]
-    $sel delete
-    foreach res $sel_resname {
-        set sel [atomselect top "${species} and (resname $res) and $acylchain_selstr"]
-        set sel_len [llength [lsort -unique [$sel get name]]]
-        # 6 is the longest chain in Martini
-        # If there is a chain longer -> the lipid is
-        # a homoacid, need to add another value to 
-        # divide by
-        if {$sel_len > 6} {
-            lappend sel_resname "${res}"
-        }
-        $sel delete
-        set acyl_num [expr $acyl_num + $sel_len]
-    }
-    set avg_acyl_chain [ expr (1.0 * $acyl_num / [llength $sel_resname]) ]
-    if {$avg_acyl_chain < 1} {
-        return 1
-    }
-    return $avg_acyl_chain
-    
-}
-
 ;# will perform qwrap or pbc wrap, depending on settings and box angles
 proc center_and_wrap_system {inpt} {
     global params
@@ -606,7 +577,7 @@ proc polarDensityBin { config_file_script } {
     set backbone_selstr $params(backbone_selstr) ;#only necessary for backwards compatibility 
     set protein_selstr $params(protein_selstr) ;#only necessary for backwards compatibility 
     source $params(helix_assignment_script)
-    foreach atseltext $params(atomsels) name $params(names) acylchain_selstr $params(acylchain_selstrs) headname $params(headnames) tailname $params(tailnames) {
+    foreach atseltext $params(atomsels) name $params(names) headname $params(headnames) tailname $params(tailnames) {
         ;# make sure the atomselection exists
         set sel [atomselect top "$atseltext"]
         set sel_num [$sel num]
@@ -647,9 +618,9 @@ proc polarDensityBin { config_file_script } {
             set expected_beads [lindex $leaf_total 1]
             set expected_lipids [lindex $leaf_total 2]
             set expected_bead_density [expr 1.0 * $expected_beads/$area]
-                puts "#Lipid atsel $name in $leaflet_str leaflet: ${expected_lipids} molecules, Num beads : ${expected_beads} beads,  Average Area : [format {%0.0f} $area] A^2, Expected Bead Density : [format {%0.5f} [expr $expected_bead_density]]/A^2, Average Chain : [avg_acyl_chain_len "$atseltext" $acylchain_selstr] beads, dr*dtheta : [format {%0.5f} [expr $params(dr)*[DtoR $params(dtheta)]]] "
-                puts $lu "#Lipid atsel $name in $leaflet_str leaflet: ${expected_lipids} molecules, Num beads : ${expected_beads} beads,  Average Area : [format {%0.0f} $area] A^2, Expected Bead Density : [format {%0.5f} [expr $expected_bead_density]]/A^2, Average Chain : [avg_acyl_chain_len "$atseltext" $acylchain_selstr] beads, dr*dtheta : [format {%0.5f} [expr $params(dr)*[DtoR $params(dtheta)]]] "
-                puts $avgfile "#Lipid atsel $name in $leaflet_str leaflet: ${expected_lipids} molecules, Num beads : ${expected_beads} beads,  Average Area : [format {%0.0f} $area] A^2, Expected Bead Density : [format {%0.5f} [expr $expected_bead_density]]/A^2, Average Chain : [avg_acyl_chain_len "$atseltext" $acylchain_selstr] beads, dr*dtheta : [format {%0.5f} [expr $params(dr)*[DtoR $params(dtheta)]]] "
+                puts "#Lipid atsel $name in $leaflet_str leaflet: ${expected_lipids} molecules, Num beads : ${expected_beads} beads,  Average Area : [format {%0.0f} $area] A^2, Expected Bead Density : [format {%0.5f} [expr $expected_bead_density]]/A^2, dr*dtheta : [format {%0.5f} [expr $params(dr)*[DtoR $params(dtheta)]]] "
+                puts $lu "#Lipid atsel $name in $leaflet_str leaflet: ${expected_lipids} molecules, Num beads : ${expected_beads} beads,  Average Area : [format {%0.0f} $area] A^2, Expected Bead Density : [format {%0.5f} [expr $expected_bead_density]]/A^2, dr*dtheta : [format {%0.5f} [expr $params(dr)*[DtoR $params(dtheta)]]] "
+                puts $avgfile "#Lipid atsel $name in $leaflet_str leaflet: ${expected_lipids} molecules, Num beads : ${expected_beads} beads,  Average Area : [format {%0.0f} $area] A^2, Expected Bead Density : [format {%0.5f} [expr $expected_bead_density]]/A^2, dr*dtheta : [format {%0.5f} [expr $params(dr)*[DtoR $params(dtheta)]]] "
         }
         puts "Processing frames, starting at frame $params(start_frame) and ending at frame $params(end_frame)."
         trajectory_leaflet_assignment $atseltext $headname $tailname   

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -514,7 +514,7 @@ proc set_parameters { config_file_script } {
         start_frame 0  
         backbone_selstr "name BB" 
         protein_selstr "name BB SC1 to SC4"
-        atsels {"POPG"}
+        atomsels {"POPG"}
         headnames {"PO4"}
         tailnames {"C4"}
         lipidbeads_selstrs {"all"}
@@ -528,7 +528,7 @@ proc set_parameters { config_file_script } {
         dr 5 
         Ntheta 50
         restrict_leaflet_sorter_to_Rmax 0
-        filenames "none"
+        filenames {"POPG"}
     }
     set nframes [molinfo top get numframes] 
     array set params [list end_frame $nframes]

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -517,8 +517,6 @@ proc set_parameters { config_file_script } {
         atomsels {"POPG"}
         headnames {"PO4"}
         tailnames {"C4"}
-        lipidbeads_selstrs {"all"}
-        acylchain_selstrs {"all"}        
         chainlist {A B C D E}
         helixlist {1 2 3 4}
         helix_assignment_script "assign_helices_ELIC_general.tcl" 

--- a/python/density.py
+++ b/python/density.py
@@ -153,7 +153,7 @@ def _parse_system_info(dat_file_header):
 
     """
     if len(dat_file_header) == 6:
-        NL, NB, BoxArea, ExpBeadDensity, NBperTail, DrDtheta = dat_file_header
+        NL, NB, BoxArea, ExpBeadDensity, _, DrDtheta = dat_file_header
     elif len(dat_file_header) == 5:
         NL, NB, BoxArea, ExpBeadDensity, DrDtheta = dat_file_header
     NL = _isolate_number_from_header_string(NL)

--- a/python/density.py
+++ b/python/density.py
@@ -152,6 +152,7 @@ def _parse_system_info(dat_file_header):
         Namedtuple containing system information output by polarDensityBin.
 
     """
+    # this is done for backwards-compatibility with a discontinued feature
     if len(dat_file_header) == 6:
         NL, NB, BoxArea, ExpBeadDensity, _, DrDtheta = dat_file_header
     elif len(dat_file_header) == 5:

--- a/python/density.py
+++ b/python/density.py
@@ -10,7 +10,7 @@ import numpy as np
 from collections import namedtuple
 
 
-SysInfo = namedtuple('SysInfo', ['NL', 'NB', 'NBperTail', 'BoxArea', 'ExpBeadDensity', 'DrDtheta'])
+SysInfo = namedtuple('SysInfo', ['NL', 'NB', 'BoxArea', 'ExpBeadDensity', 'DrDtheta'])
 Dimensions = namedtuple('Dimensions', ['dr', 'Nr', 'dtheta', 'Ntheta', 'Nframes'])
 
 
@@ -152,14 +152,16 @@ def _parse_system_info(dat_file_header):
         Namedtuple containing system information output by polarDensityBin.
 
     """
-    NL, NB, BoxArea, ExpBeadDensity, NBperTail, DrDtheta = dat_file_header
+    if len(dat_file_header) == 6:
+        NL, NB, BoxArea, ExpBeadDensity, NBperTail, DrDtheta = dat_file_header
+    elif len(dat_file_header) == 5:
+        NL, NB, BoxArea, ExpBeadDensity, DrDtheta = dat_file_header
     NL = _isolate_number_from_header_string(NL)
     NB = _isolate_number_from_header_string(NB)
     BoxArea = _isolate_number_from_header_string(BoxArea)
     ExpBeadDensity = _isolate_number_from_header_string(ExpBeadDensity)
-    NBperTail = _isolate_number_from_header_string(NBperTail)
     DrDtheta = _isolate_number_from_header_string(DrDtheta)
-    sysInfo = SysInfo(NL, NB, NBperTail, BoxArea, ExpBeadDensity, DrDtheta)
+    sysInfo = SysInfo(NL, NB, BoxArea, ExpBeadDensity, DrDtheta)
     return sysInfo
 
 


### PR DESCRIPTION
## Description
This PR allows the user to specify full atomselection text in their config file rather than limit them to only selecting resnames. Consequently, the variable $lipidbeads_selstr is removed. 

It also introduces the $filenames variable, which stores the names associated with each of the supplied atomselections.

It also removes the calculation of average acyl chain length and the variable $acylchain_selstr. 

## Usage Changes
User now sets $atomsels and $filename_stems in the config file. User no longer sets $lipids, $lipidbeads_selstrs, and $acylchain_selstrs in the config file.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Introduced variables $atomsels and $filename_stems
  - [x] Removed variables $lipids, $lipidbeads_selstrs, $acylchain_selstrs
  - [x] Removed avg_acyl_chain_length proc
  - [x] Removed NBperTail from python; made python backwards compatible

## Pre-Review checklist (PR maker)
- [x] Create tests in DTA_Testing repo
- [x] Vimdiff test results and confirm that only differences are in file header text
- [x] Confirm that Python parse_tcl_dat_file is backwards compatible 

## Review checklist (Reviewer)
- [ ] No missed "low-hanging fruit" that would substantially aid readability.
- [ ] Any "high-hanging" or "rotten" fruit is added to the issues list.
- [ ] [optional] vimdiff results in DTA_Testing/145-...
- [ ] [optional] confirm that only difference between files is in header line
- [ ] I understand what the changes are doing and how
- [ ] I understand the motivation for this PR (the PR itself is appropriately documented)

## Status
- [x] Ready for review