### PR TITLE
leaflet_sorter_0 should take average of head or tail z

### DIFF
--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -184,11 +184,11 @@ proc center_and_wrap_system {inpt} {
 proc leaflet_sorter_0 {atsel_in head tail frame_i} {
     #puts "Sorting into leaflets using leaflet_sorter_0"
     set sel_resid [atomselect top "$atsel_in" frame $frame_i]
-    set sel_head [atomselect top "$atsel_in and name $head" frame $frame_i]
-    set sel_tail [atomselect top "$atsel_in and name $tail" frame $frame_i]
+    set sel_head [atomselect top "$atsel_in and $head" frame $frame_i]
+    set sel_tail [atomselect top "$atsel_in and $tail" frame $frame_i]
     
-    set head_Z [${sel_head} get z] 
-    set tail_Z [${sel_tail} get z] 
+    set head_Z [vecmean [${sel_head} get z]]
+    set tail_Z [vecmean [${sel_tail} get z]]
     
     if {$head_Z < $tail_Z } { 
         $sel_resid set user2 -1
@@ -515,8 +515,8 @@ proc set_parameters { config_file_script } {
         backbone_selstr "name BB" 
         protein_selstr "name BB SC1 to SC4"
         atomsels {"resname POPG"}
-        headnames {"PO4"}
-        tailnames {"C4"}
+        headnames {"name PO4"}
+        tailnames {"name C4A C4B"}
         chainlist {A B C D E}
         helixlist {1 2 3 4}
         helix_assignment_script "assign_helices_ELIC_general.tcl" 


### PR DESCRIPTION
## Description
If a user gave leaflet_sorter_0 multiple head or tail names it would not know what to do with them and error out. It now takes the mean height of any selection that matches what the user provides.

## Usage Changes
User now needs to specify full atomselection text rather than just a bead name if they are choosing to use leaflet_sorter_0. IE user now needs to specify 'name PO4' instead of just 'PO4' for the $headnames variable in their config file.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Change leaflet_sorter_0 to take vecmean of [$sel get z] 
  - [x] Change leaflet_sorter_0 to not insert 'name' into the atomselection text
  - [x] Change default values so they contain 'name'

## Pre-Review checklist (PR maker)
- [x] Confirm that this does not cause errors
- [x] Confirm that leaflet sorting works as expected (I ran it on the CDL1 simulation and visually checked for correct leaflet assignment)

## Review checklist (Reviewer)
- [x] No missed "low-hanging fruit" that would substantially aid readability.
- [x] Any "high-hanging" or "rotten" fruit is added to the issues list.
- [x] I understand what the changes are doing and how
- [x] I understand the motivation for this PR (the PR itself is appropriately documented)

## Status
- [x] Ready for review