### PR TITLE
fixed params bug

### DIFF
--- a/accessible_area/do_get_counts.tcl
+++ b/accessible_area/do_get_counts.tcl
@@ -36,8 +36,8 @@ set fieldid "user2"
 
 
 if {$ASSIGN_LEAFLETS == 1} {
-	if {[lsearch -exact "1 3" $params(leaflet_sorting_algorithm)] == -1} {
-        	puts "Option $params(leaflet_sorting_algorithm) not recognized as a leaflet sorting option. Defaulting to option 1."
+	if {[lsearch -exact "1 3" $leaflet_sorter_option] == -1} {
+        	puts "Option ${leaflet_sorter_option} not recognized as a leaflet sorting option. Defaulting to option 1."
 		set leaflet_sorter_option 1
 	}
 	foreach atsel $atsels {


### PR DESCRIPTION
## Description
do_get_counts.tcl was trying to use a global variable that is only available in polarDensityBin. It now uses what it has.

## Usage Changes
None.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] switched variable name so error no longer occurs

## Pre-Review checklist (PR maker)
- [x] Confirm this feature now works without error

## Review checklist (Reviewer)
- [x] No missed "low-hanging fruit" that would substantially aid readability.
- [x] Any "high-hanging" or "rotten" fruit is added to the issues list.
- [x] I understand what the changes are doing and how
- [x] I understand the motivation for this PR (the PR itself is appropriately documented)

## Status
- [x] Ready for review