### PR TITLE
170 need way to assign bin numbers to user field

### DIFF
--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -480,9 +480,7 @@ proc loop_over_frames {shell atseltext start_frame end_frame ri rf flower fupper
     for {set frm $params(start_frame)} {$frm < ${end_frame}} {incr frm $params(dt)} {
         $shell frame $frm
         $shell update 
-        if {$params(save_bins)} {
-            $shell set user3 $r_index
-        }
+        $shell set user3 $r_index
         set singleFrame_counts [loop_over_atoms $shell $atseltext $frm]
         set singleFrame_upper [lindex $singleFrame_counts 1] 
         set singleFrame_lower [lindex $singleFrame_counts 0]
@@ -557,7 +555,6 @@ proc set_parameters { config_file_script } {
         Ntheta 50
         restrict_leaflet_sorter_to_Rmax 0
         filename_stems {"POPG"}
-        save_bins 0
     }
     set nframes [molinfo top get numframes] 
     array set params [list end_frame $nframes]


### PR DESCRIPTION
## Description
Theta bin indices were already being saved to the user field. Now radial bin indices are saved to user3 as well.

## Usage Changes
None.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Save radial bin index to user3 field
  - [x] Save theta bin index to user (instead of theta bin index + 1, which is what we had been doing previously)

## Pre-Review checklist (PR maker)
- [x] Run test system with 2 lipids, ensure that bins line up between user values and density heatmap plots.
- [x] Save test system and test results to DTA_Testing repo in directory 170-need_way...

## Review checklist (Reviewer)
- [x] No missed "low-hanging fruit" that would substantially aid readability.
- [x] Any "high-hanging" or "rotten" fruit is added to the issues list.
- [x] I understand what the changes are doing and how
- [x] I understand the motivation for this PR (the PR itself is appropriately documented)

## Status
- [x] Ready for review