### PR TITLE
173 create heatmap figure and axes assumes two leaflets

### DIFF
--- a/python/DTA/plotting.py
+++ b/python/DTA/plotting.py
@@ -184,8 +184,8 @@ def create_heatmap_figure_and_axes(row_names, col_names, figwidth, figheight, he
         Figure width.
     figheight : float
         Figure height.
-    helices : list
-        The outer and inner helix coordinates, in that order.
+    helices : list of ndarrays
+        An ndarray of helix coordinates for each panel of the figure.
 
     Returns
     -------
@@ -201,9 +201,11 @@ def create_heatmap_figure_and_axes(row_names, col_names, figwidth, figheight, he
     assert len(col_names) > 0, "col_names cannot be an empty list"
     assert isinstance(helices, list), "helices must be a list"
     assert isinstance(helices[0], np.ndarray), "helices must be a list of ndarrays"
-    assert len(helices) > 0, "helices cannot be an empty list"
+    
     num_rows = len(row_names)
     num_cols = len(col_names)
+    assert len(helices) == num_rows * num_cols, f"Not enough helix coordinate sets ({str(len(helices))}) for all panels {str(num_rows * num_cols)} in the figure"
+
     fig = plt.figure(figsize=(figwidth, figheight))
     gs = gridspec.GridSpec(num_rows, num_cols, figure=fig, wspace=0.15, hspace=0.15)
     for gridbox in range(num_rows * num_cols):
@@ -213,7 +215,7 @@ def create_heatmap_figure_and_axes(row_names, col_names, figwidth, figheight, he
         if gridbox % num_cols == 0:
             # put the row name to the left of the axes object
             ax.text(-0.5, 0.5, row_names[gridbox // num_cols], transform=ax.transAxes, fontsize='medium', va='center', fontfamily='serif')
-        ax = plot_helices(helices[gridbox % num_cols], False, ax, 50)
+        ax = plot_helices(helices[gridbox], False, ax, 50)
     return fig, fig.axes
 
 


### PR DESCRIPTION
## Description
The create_heatmap_figure_and_axes function assumed that there would only ever be two leaflets and that their names were "outer" and "inner". This has been fixed so that the user can now specify how many columns they want on their heatmap and what they should be named.

## Usage Changes
The function now takes a list of column names as an additional argument. Two unused arguments have been removed. Helices is now a list with as many items as there are panels in the figure.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Allow user to specify column names
  - [x] Rename variable "lipids" with more generic "row_names"
  - [x] plot_helices now appropriately called on all gridboxes
  - [x] type hint corrected for figheight and figwidth
  - [x] Removes two unused variables (cmap and v_values)

## Pre-Review checklist (PR maker)
- [x] New configuration parameters are documented (Usage changes above)
- [x] Create heatmap with two columns and ensure it looks as it should
- [x] Create heatmap with only one column and ensure it looks as it should
- [x] Save both heatmaps to DTA_Testing repo
- [x] Make fontsize the same for column and row labels

## Review checklist (Reviewer)
- [x] New functions/variables are named appropriately
- [x] No missed "low-hanging fruit" that would substantially aid readability.
- [x] Any "high-hanging" or "rotten" fruit is added to the issues list.
- [x] I understand what the changes are doing and how
- [x] I understand the motivation for this PR (the PR itself is appropriately documented)

## Status
- [x] Ready for review