### PR TITLE
185 fix ylabel in plot_histogram

### DIFF
--- a/python/DTA/plotting.py
+++ b/python/DTA/plotting.py
@@ -328,8 +328,10 @@ def plot_histogram(ax, data, area, bulk_mode="NULL", plot_probability=False):
     """
     if plot_probability:
         data = data / np.sum(data)
+        ax.set_ylabel("Probability")
+    else:
+        ax.set_ylabel("Counts")
     ax.plot(range(len(data)), data)
-    ax.set_ylabel("Probability")
     ax.set_xlabel(f"Number of beads in an area about {area} " + r"$\AA^2$")
     mode = calculate_hist_mode(data)
     ax.vlines([mode], 0, np.max(data), color='black', linestyles='dashed', label=f"mode={mode}")


### PR DESCRIPTION
## Description
The plot_histogram function would label the y axis as "Probability" regardless of whether you were plotting a probability (plot_probability=True) or were plotting the raw counts (plot_probability=False). This has been fixed.

## Usage Changes
None

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Fixed y axis label in plot_histogram

## Pre-Review checklist (PR maker)
- [x] Test to make sure y axis shows up correctly in both conditions

## Review checklist (Reviewer)
- [ ] No missed "low-hanging fruit" that would substantially aid readability.
- [ ] Any "high-hanging" or "rotten" fruit is added to the issues list.
- [ ] I understand what the changes are doing and how
- [ ] I understand the motivation for this PR (the PR itself is appropriately documented)

## Status
- [x] Ready for review