### PR TITLE
211 lint utils

### DIFF
--- a/python/DTA/utils.py
+++ b/python/DTA/utils.py
@@ -108,8 +108,8 @@ def calculate_hist_mean(counts_data):
     """
     total_N = np.sum(counts_data)
     sum_i = 0
-    for i in range(len(counts_data)):
-        sum_i += i * counts_data[i]
+    for index, value in enumerate(counts_data):
+        sum_i += index * value
     mean = sum_i / total_N
     return mean
 


### PR DESCRIPTION
## Description
Pylint notified me that I had A) mispelled a variable name, B) imported external libraries before standard libraries, and C) missed an opportunity to use enumerate instead of range. These have all been fixed. 

## Usage Changes
None

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Refactor P_unnoc to P_unocc
  - [x] Switch order of imports to make Pylint happy
  - [x] Use enumerate instead of range on line 111

## Pre-Review checklist (PR maker)
- [x] Run the notebook cells and ensure no errors

## Review checklist (Reviewer)
- [x] I understand what the changes are doing and how
- [x] I understand the motivation for this PR (the PR itself is appropriately documented)
- [x] All notebooks still function correctly

## Status
- [x] Ready for review
