### PR TITLE
197 two procs do not use global M_PI

### DIFF
--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -52,8 +52,8 @@ proc lcount list {
 # Outputs:
 #   float: the same angle in degrees
 proc RtoD {r} {
-    global pi
-    return [expr $r*180.0/$pi]
+    global M_PI
+    return [expr $r*180.0/$M_PI]
 }
 
 # get_theta
@@ -65,10 +65,10 @@ proc RtoD {r} {
 # Outputs:
 #   float: the angle of the point in degrees relative to the origin
 proc get_theta {x y} {
-    global pi
+    global M_PI
     set tmp  [expr {atan2($y,$x)}]
     if {$tmp < 0} {
-        set theta [expr 2*$pi + $tmp]    
+        set theta [expr 2*$M_PI + $tmp]    
     } else {
         set theta $tmp
     }


### PR DESCRIPTION
## Description
Two procs used a string representation of pi. Switched to using the built-in global M_PI. Closes #197 

## Usage Changes
None

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] RtoD and get_theta now use global M_PI

## Pre-Review checklist (PR maker)
- [x] Run polarDensityBin without errors

## Review checklist (Reviewer)
- [x] No missed "low-hanging fruit" that would substantially aid readability.
- [x] Any "high-hanging" or "rotten" fruit is added to the issues list.
- [x] I understand what the changes are doing and how
- [x] I understand the motivation for this PR (the PR itself is appropriately documented)

## Status
- [x] Ready for review
