### PR TITLE
227 replaced dt with leaflet_reassign_interval in leaflet sorting

### DIFF
--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -381,8 +381,8 @@ proc trajectory_leaflet_assignment {atseltext headname tailname} {
                 puts "Defaulting to z=0 as the reference height to sort by."
         }
     }
-    for {set update_frame $params(start_frame)} {$update_frame < $params(end_frame)} {incr update_frame $params(dt)} {
-        frame_leaflet_assignment $atseltext $headname $tailname $update_frame [expr $update_frame + $params(dt)] $params(restrict_leaflet_sorter_to_Rmax)
+    for {set update_frame $params(start_frame)} {$update_frame < $params(end_frame)} {incr update_frame $params(leaflet_reassign_interval)} {
+        frame_leaflet_assignment $atseltext $headname $tailname $update_frame [expr $update_frame + $params(leaflet_reassign_interval)] $params(restrict_leaflet_sorter_to_Rmax)
         incr num_reassignments
     }
     puts "Checked for leaflet reassignments $num_reassignments times."


### PR DESCRIPTION
## Description
Closes #227 

## Usage Changes
$leaflet_reassign_interval will actually control the leaflet sorting interval now instead of $dt.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] replace $dt with $leaflet_reassign_interval in trajectory_leaflet_assignment{}

## Pre-Review checklist (PR maker)
- [x] Tested to make sure leaflet assignment works as expected

## Review checklist (Reviewer)
- [x] No missed "low-hanging fruit" that would substantially aid readability.
- [x] Any "high-hanging" or "rotten" fruit is added to the issues list.
- [x] I understand what the changes are doing and how
- [x] I understand the motivation for this PR (the PR itself is appropriately documented)

## Status
- [x] Ready for review
