### PR TITLE
Fix error check in loop_over_atoms

### DIFF
--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -479,8 +479,8 @@ proc loop_over_atoms {shell atseltext frm} {
     set indexs [$shell get index]
     set theta_high_out [list]
     set theta_low_out [list]
-    set leaflet 0
     foreach indx $indexs {
+        set leaflet 0
         #loop over atoms (or beads if CG) in the shell
         set atsel "($atseltext) and index $indx"
         set thislipid [atomselect top $atsel frame $frm]


### PR DESCRIPTION
The loop_over_atoms proc loops over each index in the shell selection. It checks to make sure everything gets assigned a leaflet. Unfortunately, after the first loop this error check is always going to pass because leaflet never gets set to 0 again. This patch fixes this.

## Usage Changes
None

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - move variable reset inside of for loop

## Pre-Review checklist (PR maker)
- [ ] DTA runs without errors
- [ ] Confirm same output from TCL

## Review checklist (Reviewer)
- [ ] No missed "low-hanging fruit" that would substantially aid readability.
- [ ] Any "high-hanging" or "rotten" fruit is added to the issues list.
- [ ] I understand what the changes are doing and how
- [ ] I understand the motivation for this PR (the PR itself is appropriately documented)
- [ ] All notebooks still function correctly

## Status
- [ ] Ready for review
