### PR TITLE
274 merge gui renderer to main

### DIFF
--- a/python/dta/gui/README.md
+++ b/python/dta/gui/README.md
@@ -1,0 +1,289 @@
+# Python Package Architecture
+
+This folder contains the core Python implementation for interactive polar-bin selection using Matplotlib.  
+
+---
+
+## Overview
+
+The system allows a user to:
+
+- Interactively select polar bins using click-and-drag gestures
+- Add to, subtract from, or replace selections using modifier keys
+- Drag outside an Axes and still commit the selection correctly
+- Work with multiple Axes in the same Figure without state leakage
+
+To support this reliably, the code is organized using a **Model–View–Controller (MVC)** architecture.
+
+---
+
+## Model–View–Controller (MVC)
+
+### Roles
+
+- **Model**  
+  Owns domain state and pure geometry rules.  
+  Has no knowledge of Matplotlib events or rendering.
+
+- **View**  
+  Responsible only for drawing on Matplotlib Axes.
+
+- **Controller**  
+  Translates user input (mouse + modifiers) into model updates and view updates.  
+  Owns all gesture and interaction state.
+
+---
+
+## MVC Class Diagram
+
+```mermaid
+classDiagram
+
+%% =========================
+%% MVC Stereotypes
+%% =========================
+
+class PolarBinGrid:::model
+class GridDim:::model
+class BinAddress:::model
+class Coordinate:::model
+class BinEdge:::model
+class BinSelection:::model
+
+class SelectionRenderer:::view
+
+class SiteSelector:::controller
+class SiteSelectorManager:::controller
+class SelectorDragState:::controller
+class SelectionOperations:::controller
+
+<<Model>> PolarBinGrid
+<<Model>> GridDim
+<<Model>> BinAddress
+<<Model>> Coordinate
+<<Model>> BinEdge
+<<Model>> BinSelection
+
+<<View>> SelectionRenderer
+
+<<Controller>> SiteSelector
+<<Controller>> SiteSelectorManager
+<<Controller>> SelectorDragState
+<<Controller>> SelectionOperations
+
+
+%% =========================
+%% Model
+%% =========================
+
+namespace DTA.bin_logic.polar_grid {
+class PolarBinGrid {
+    +r: GridDim
+    +theta: GridDim
+    +r_grid: ndarray
+    +theta_grid: ndarray
+    +map_coord_to_bin_idx(coord: Coordinate) BinAddress | None
+    +bins_in_region(corner1: Coordinate, corner2: Coordinate, crosses_theta_boundary: bool) Set~BinAddress~
+    +list_all_exposed_edges(bins: Set~BinAddress) List~BinEdge~
+    +calc_bin_area(bin_address: BinAddress) float
+    -determine_exposed_bin_edges(mask: ndarray, bin_address: BinAddress) list~BinEdge~
+    -determine_bin_edge(bin_address: BinAddress, side: str) BinEdge
+}
+class GridDim {
+    +lower_bound: float
+    +upper_bound: float
+    +n_bins: int
+    +bin_width: float
+    +bin_edges: ndarray
+}
+}
+
+namespace DTA.bin_logic.utils {
+class NamedTuple {}
+class BinAddress {
+    +r_index: Int
+    +theta_index: Int
+}
+class Coordinate {
+    +r_coord: float
+    +theta_coord: float
+}
+class BinEdge {
+    +endpoint1: Coordinate
+    +endpoint2: Coordinate
+}
+}
+namespace DTA.bin_logic.bin_selection {
+class BinSelection {
+    +bins : Set~BinAddress~
+    -selection_history*
+    +set_bins(bins: Set~BinAddress~)
+    +get_bins() Set~BinAddress~
+    +reset()
+    +undo()*
+    +redo()*
+}
+}
+
+%% =========================
+%% View
+%% =========================
+namespace DTA.gui.renderers {
+class SelectionRenderer {
+    +ax: Axes
+    +preview_artists: List~Artist~
+    +selection_artists: List~Artist~
+    +defaul_preview_kwargs : dict
+    +selection_kwargs : dict
+    +draw_bin_edges(edges: List~BinEdge~, preview: bool) None
+    -draw_edge(edge: BinEdge, kwargs: dict) matplotlib.artist.Artist
+    +clear_artists(clear_preview: bool) None
+    +shade_interior_region()*
+}
+class matplotlib.axes.Axes {}
+}
+
+%% =========================
+%% Controller
+%% =========================
+
+namespace DTA.gui.selector_state {
+class SelectionOperations {
+    <<enumeration>>
+    REPLACE
+    ADD
+    SUBTRACT
+}
+
+class SelectorDragState {
+    <<dataclass>>
+    -drag_start: Coordinate | None
+    -last_theta: float | None
+    -operation: SelectionOperation
+    +start_drag() None
+    +reset() None
+}
+}
+
+namespace DTA.gui.selectors {
+class SiteSelector {
+    +selection: BinSelection
+    +grid: PolarBinGrid
+    +renderer: SelectionRenderer
+    +drag_tracker: SelectorDragState
+    +current_preview_bins: Set~BinAddress~
+    +on_activate() None
+    +on_press(event: MouseEvent, operation: SelectionOperation) bool
+    +on_motion(event: MouseEvent) bool
+    +on_release(_event: MouseEvent) bool
+    +on_deactivate() None
+    -calculate_preview_bins(bins: Set~BinAddress~) Set~BinAddress~
+    -save_to_selection_history(last_bins: Set~BinAddress~)*
+}
+
+class SiteSelectorManager {
+    +fig: Figure
+    -selectors: dict~SiteSelector~
+    -active: dict
+    -drag_owner: SiteSelector | None
+    -cids: List~int~
+    +register(selector: SiteSelector, active: bool)
+    +set_active(selector: SiteSelector)
+    -on_press_event(event: MouseEvent)
+    -on_motion_event(event: MouseEvent)
+    -on_release_event(event: MouseEvent)
+    -mods_from_mouse_event(event: MouseEvent) Set~str~
+    -determine_operation_from_key_presses(event: MouseEvent) SelectionOperation
+}
+class matplotlib.figure.Figure {}
+}
+%% =========================
+%% Relationships
+%% =========================
+
+SiteSelector *-- PolarBinGrid : defines polar lattice logic
+SiteSelector *-- SelectionRenderer : draws things & keeps track of what's drawn
+SiteSelector *-- BinSelection : holds & updates bin selection
+SiteSelector *-- SelectorDragState : keeps track of mouse drags and key-press modifiers
+SelectorDragState ..> SelectionOperations : enumerates allowed modes
+
+SelectionRenderer *-- matplotlib.axes.Axes
+
+SiteSelectorManager o-- SiteSelector : coordinates behavior for one Axes
+SiteSelectorManager *-- matplotlib.figure.Figure
+
+NamedTuple <|-- BinAddress : is a
+NamedTuple <|-- Coordinate : is a
+NamedTuple <|-- BinEdge : is a
+
+PolarBinGrid o-- GridDim
+
+%% =========================
+%% Styling (MVC color coding)
+%% =========================
+classDef model fill:#E8F5E9,stroke:#2E7D32,stroke-width:1px,color:#1B5E20;
+classDef view fill:#E3F2FD,stroke:#1565C0,stroke-width:1px,color:#0D47A1;
+classDef controller fill:#FFF3E0,stroke:#EF6C00,stroke-width:1px,color:#E65100;
+```
+
+```mermaid
+classDiagram
+  direction TB
+  namespace Legend {
+    class Owner
+    class Dog
+    class SocialSecurityNumber
+    class Handedness {
+      RIGHTHANDED
+      LEFTHANDED
+      AMBIDEXTROUS
+      NO_HANDS
+    }}
+    Owner o-- Dog : Owner "has a" Dog - they could have multiple dogs
+    Owner *-- SocialSecurityNumber : Owner "has a" SSN - can only have one
+    Owner ..> Handedness : Owner "can be one of these enumerations"
+  
+```
+
+
+## Sequence Diagram Depicting SiteSelectorManager Response to Mouse Events
+
+```mermaid
+flowchart TD
+    A[Event received by SiteSelectorManager] --> B{Event type?}
+
+    B -->|button_press_event| C[SiteSelectorManager._on_press_event]
+    B -->|motion_notify_event| D[SiteSelectorManager._on_motion_event]
+    B -->|button_release_event| E[SiteSelectorManager._on_release_event]
+
+    %% PRESS FLOW
+    C --> C1{Is MouseEvent inside an Axes?}
+    C1 -->|No| C0
+    C1 -->|Yes| C2{Is there an active SiteSelector assigned to that Axes?}
+    C2 --> |No| C0
+    C2 --> |Yes| C3[self._drag_owner = active SiteSelector]
+    C3 --> C4[Check if shift/ctrl pressed; save to self._drag_owner.drag_tracker.mods ]
+    C4 --> C5[Call self._drag_owner's on_press method] --> C6{Was anything new drawn?}
+    C6 --> |No| C0
+    C6 --> |Yes| C7[self.fig.canvas.draw_idle]
+    C7 --> C0[Return]
+
+    %% MOTION FLOW
+    D --> D1{Is there a self._drag_owner?}
+    D1 -->|No| D0
+    D1 -->|Yes| D2[Call self._drag_owner's on_motion method]
+    D2 --> D6{Was anything new drawn?}
+    D6 --> |No| D0
+    D6 --> |Yes| D7[self.fig.canvas.draw_idle]
+    D7 --> D0[Return]
+
+    %% RELEASE FLOW
+    E --> E1{Is there a self._drag_owner?}
+    E1 --> |No|E0[Return]
+    E1 --> |Yes|E2[Call self._drag_owner's on_release method]
+    E2 --> E3{Was anything new drawn?}
+    E3 --> |No|E6
+    E3 --> |Yes|E4[self.fig.canvas.draw_idle]
+    E4 -->E6[Reset self._drag_owner]
+    E6 --> E0
+```

--- a/python/dta/gui/__init__.py
+++ b/python/dta/gui/__init__.py
@@ -1,2 +1,3 @@
 """Import the necessary classes."""
 from .selector_state import SelectionOperation, SelectorDragState
+from .renderers import SelectionRenderer

--- a/python/dta/gui/renderers.py
+++ b/python/dta/gui/renderers.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Matplotlib renderers for polar bin selection.
+
+This module contains view-layer classes responsible for drawing selection
+outlines using Matplotlib.
+
+All event handling and gesture interpretation is handled by
+Matplotlib controllers in selectors.py.
+"""
+from collections.abc import Iterable
+import matplotlib
+from dta.bin_logic.utils import BinEdge
+
+
+class SelectionRenderer:
+    """Renderer for drawing polar objects on a matplotlib Axes."""
+
+    def __init__(self, ax: matplotlib.axes.Axes, plot_kwargs: dict = None) -> None:
+        """
+        Create a SelectionRenderer object and tie it to an Axes instance.
+
+        Default plotting colors are set, but can be overridden or added to when
+        calling drawing methods.
+
+        Parameters
+        ----------
+        ax : matplotlib.axes.Axes
+            Polar axes used for drawing.
+        plot_kwargs : dict
+            Dictionary of matplotlib.pyplot keywords for drawing bin edges.
+        """
+        self.ax = ax
+        self.preview_artists = []
+        self.selection_artists = []
+
+        self.default_preview_kwargs = {
+            "color": "orange",
+            "lw": 2.0,
+            "zorder": 1000
+        }
+        default_selection_kwargs = {
+            "color": "red",
+            "lw": 2.0,
+            "zorder": 20
+        }
+        if plot_kwargs is not None:
+            default_selection_kwargs.update(plot_kwargs)
+        self.selection_kwargs = default_selection_kwargs
+
+    def draw_bin_edges(
+        self,
+        edges: list[BinEdge],
+        preview: bool = True
+    ) -> None:
+        """
+        Draw a collection of bin edges.
+
+        Parameters
+        ----------
+        edges : set[BinEdge]
+            Edges to draw.
+        preview : bool, optional
+            If True, draw an orange selection preview. If False, draw actual
+            selection.
+
+        Side Effects
+        ------------
+        - Removes previous artists
+        - Saves drawn artists to the correct SelectionRenderer attribute.
+        """
+        self.clear_artists(clear_preview=True)
+        self.clear_artists(clear_preview=False)
+        if preview:
+            kwargs = self.default_preview_kwargs
+            artists = self.preview_artists
+        else:
+            kwargs = self.selection_kwargs
+            artists = self.selection_artists
+
+        for edge in edges:
+            artists.append(self._draw_edge(edge, kwargs))
+
+    def _draw_edge(self, edge: BinEdge, kwargs: dict) -> matplotlib.artist.Artist:
+        """
+        Draw a BinEdge on the polar Axes and return the artist generated.
+
+        Parameters
+        ----------
+        edge : BinEdge
+            The BinEdge you wish to plot.
+        kwargs : dict
+            The matplotlib plotting kwargs to use when plotting.
+
+        Side Effects
+        ------------
+        Plots the BinEdge on the Axes.
+        """
+        theta_endpoints = (edge.endpoint1[1], edge.endpoint2[1])
+        r_endpoints = (edge.endpoint1[0], edge.endpoint2[0])
+        return self.ax.plot(theta_endpoints, r_endpoints, **kwargs)[0]
+
+    def clear_artists(self, clear_preview: bool = True) -> None:
+        """
+        Remove Matplotlib artists from the Axes.
+
+        Parameters
+        ----------
+        clear_preview : bool, optional
+            If True, clear the preview from the Axes. If False, clear the
+            selection from the Axes.
+
+        Side Effects
+        ------------
+        - Calls ``artist.remove()`` on each artist.
+        - Empties the preview_artists or selection_artists attribute in-place.
+        """
+        if clear_preview:
+            artists = self.preview_artists
+        else:
+            artists = self.selection_artists
+
+        for artist in artists:
+            artist.remove()
+
+        artists.clear()
+
+    def shade_interior_region(self) -> None:
+        """Hold space for future method."""

--- a/test_files/unit_tests/test_selection_renderers.py
+++ b/test_files/unit_tests/test_selection_renderers.py
@@ -1,0 +1,255 @@
+"""Unit tests for matplotlib selection renderers."""
+
+from collections import namedtuple
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from dta.gui import SelectionRenderer
+
+
+DummyEdge = namedtuple("DummyEdge", ["endpoint1", "endpoint2"])
+
+
+@pytest.fixture
+def polar_ax():
+    """Create a disposable polar Axes for renderer tests."""
+    fig, ax = plt.subplots(subplot_kw={"projection": "polar"})
+    yield ax
+    plt.close(fig)
+
+
+def test_renderer_initializes_with_default_kwargs(polar_ax):
+    """SelectionRenderer stores its Axes and default plotting options."""
+    renderer = SelectionRenderer(polar_ax)
+
+    assert renderer.ax is polar_ax
+    assert renderer.preview_artists == []
+    assert renderer.selection_artists == []
+
+    assert renderer.default_preview_kwargs == {
+        "color": "orange",
+        "lw": 2.0,
+        "zorder": 1000,
+    }
+    assert renderer.selection_kwargs == {
+        "color": "red",
+        "lw": 2.0,
+        "zorder": 20,
+    }
+
+
+def test_renderer_merges_selection_kwargs_with_defaults(polar_ax):
+    """Custom plot kwargs override selection defaults without affecting preview defaults."""
+    renderer = SelectionRenderer(
+        polar_ax,
+        plot_kwargs={
+            "color": "blue",
+            "alpha": 0.5,
+        },
+    )
+
+    assert renderer.selection_kwargs == {
+        "color": "blue",
+        "lw": 2.0,
+        "zorder": 20,
+        "alpha": 0.5,
+    }
+    assert renderer.default_preview_kwargs == {
+        "color": "orange",
+        "lw": 2.0,
+        "zorder": 1000,
+    }
+
+
+def test_draw_bin_edges_draws_preview_edges_by_default(polar_ax):
+    """draw_bin_edges stores preview artists when preview is left as True."""
+    renderer = SelectionRenderer(polar_ax)
+
+    edges = [
+        DummyEdge(endpoint1=(1.0, 0.0), endpoint2=(1.0, np.pi / 2)),
+        DummyEdge(endpoint1=(2.0, np.pi), endpoint2=(3.0, np.pi)),
+    ]
+
+    renderer.draw_bin_edges(edges)
+
+    assert len(renderer.preview_artists) == 2
+    assert renderer.selection_artists == []
+    assert len(polar_ax.lines) == 2
+    assert renderer.preview_artists == list(polar_ax.lines)
+
+
+def test_draw_bin_edges_draws_selection_edges_when_preview_false(polar_ax):
+    """draw_bin_edges stores selection artists when preview is False."""
+    renderer = SelectionRenderer(polar_ax)
+
+    edges = [
+        DummyEdge(endpoint1=(1.0, 0.0), endpoint2=(1.0, np.pi / 2)),
+        DummyEdge(endpoint1=(2.0, np.pi), endpoint2=(3.0, np.pi)),
+    ]
+
+    renderer.draw_bin_edges(edges, preview=False)
+
+    assert renderer.preview_artists == []
+    assert len(renderer.selection_artists) == 2
+    assert len(polar_ax.lines) == 2
+    assert renderer.selection_artists == list(polar_ax.lines)
+
+
+def test_draw_bin_edges_uses_theta_as_x_and_radius_as_y(polar_ax):
+    """draw_bin_edges converts BinEdge-style endpoints into polar plot coordinates."""
+    renderer = SelectionRenderer(polar_ax)
+
+    edge = DummyEdge(
+        endpoint1=(1.0, 0.25 * np.pi),
+        endpoint2=(2.0, 0.75 * np.pi),
+    )
+
+    renderer.draw_bin_edges([edge])
+    artist = renderer.preview_artists[0]
+
+    np.testing.assert_allclose(
+        artist.get_xdata(),
+        [0.25 * np.pi, 0.75 * np.pi],
+    )
+    np.testing.assert_allclose(
+        artist.get_ydata(),
+        [1.0, 2.0],
+    )
+
+
+def test_draw_bin_edges_uses_preview_kwargs_for_preview_edges(polar_ax):
+    """Preview edges use the renderer's preview plotting kwargs."""
+    renderer = SelectionRenderer(polar_ax)
+
+    edge = DummyEdge(endpoint1=(1.0, 0.0), endpoint2=(1.0, np.pi))
+
+    renderer.draw_bin_edges([edge])
+    artist = renderer.preview_artists[0]
+
+    assert artist.get_color() == "orange"
+    assert artist.get_linewidth() == 2.0
+    assert artist.get_zorder() == 1000
+
+
+def test_draw_bin_edges_uses_selection_kwargs_for_selection_edges(polar_ax):
+    """Selection edges use the renderer's selection plotting kwargs."""
+    renderer = SelectionRenderer(
+        polar_ax,
+        plot_kwargs={
+            "color": "green",
+            "lw": 4.0,
+            "zorder": 30,
+        },
+    )
+
+    edge = DummyEdge(endpoint1=(1.0, 0.0), endpoint2=(1.0, np.pi))
+
+    renderer.draw_bin_edges([edge], preview=False)
+    artist = renderer.selection_artists[0]
+
+    assert artist.get_color() == "green"
+    assert artist.get_linewidth() == 4.0
+    assert artist.get_zorder() == 30
+
+
+def test_draw_bin_edges_clears_existing_preview_before_redrawing(polar_ax):
+    """Drawing new edges removes stale preview artists before storing new ones."""
+    renderer = SelectionRenderer(polar_ax)
+
+    first_edge = DummyEdge(endpoint1=(1.0, 0.0), endpoint2=(1.0, np.pi))
+    second_edge = DummyEdge(endpoint1=(2.0, 0.0), endpoint2=(2.0, np.pi))
+
+    renderer.draw_bin_edges([first_edge])
+    old_artist = renderer.preview_artists[0]
+
+    renderer.draw_bin_edges([second_edge])
+
+    assert old_artist not in polar_ax.lines
+    assert len(renderer.preview_artists) == 1
+    assert len(polar_ax.lines) == 1
+
+    np.testing.assert_allclose(
+        renderer.preview_artists[0].get_ydata(),
+        [2.0, 2.0],
+    )
+
+
+def test_draw_bin_edges_clears_existing_selection_before_redrawing(polar_ax):
+    """Drawing new selection edges removes stale selection artists."""
+    renderer = SelectionRenderer(polar_ax)
+
+    first_edge = DummyEdge(endpoint1=(1.0, 0.0), endpoint2=(1.0, np.pi))
+    second_edge = DummyEdge(endpoint1=(2.0, 0.0), endpoint2=(2.0, np.pi))
+
+    renderer.draw_bin_edges([first_edge], preview=False)
+    old_artist = renderer.selection_artists[0]
+
+    renderer.draw_bin_edges([second_edge], preview=False)
+
+    assert old_artist not in polar_ax.lines
+    assert len(renderer.selection_artists) == 1
+    assert len(polar_ax.lines) == 1
+
+    np.testing.assert_allclose(
+        renderer.selection_artists[0].get_ydata(),
+        [2.0, 2.0],
+    )
+
+
+def test_draw_bin_edges_clears_both_preview_and_selection_artists(polar_ax):
+    """Drawing either preview or selection clears both existing artist groups."""
+    renderer = SelectionRenderer(polar_ax)
+
+    preview_edge = DummyEdge(endpoint1=(1.0, 0.0), endpoint2=(1.0, np.pi))
+    selection_edge = DummyEdge(endpoint1=(2.0, 0.0), endpoint2=(2.0, np.pi))
+
+    renderer.draw_bin_edges([preview_edge])
+    renderer.draw_bin_edges([selection_edge], preview=False)
+
+    assert renderer.preview_artists == []
+    assert len(renderer.selection_artists) == 1
+    assert len(polar_ax.lines) == 1
+
+
+def test_draw_bin_edges_with_empty_iterable_clears_existing_artists(polar_ax):
+    """Drawing an empty edge list clears stale artists and draws nothing."""
+    renderer = SelectionRenderer(polar_ax)
+
+    edge = DummyEdge(endpoint1=(1.0, 0.0), endpoint2=(1.0, np.pi))
+
+    renderer.draw_bin_edges([edge])
+    assert len(polar_ax.lines) == 1
+
+    renderer.draw_bin_edges([])
+
+    assert renderer.preview_artists == []
+    assert renderer.selection_artists == []
+    assert len(polar_ax.lines) == 0
+
+
+def test_clear_artists_removes_preview_artists_only(polar_ax):
+    """clear_artists removes preview artists when clear_preview is True."""
+    renderer = SelectionRenderer(polar_ax)
+
+    edge = DummyEdge(endpoint1=(1.0, 0.0), endpoint2=(1.0, np.pi))
+    renderer.draw_bin_edges([edge])
+
+    renderer.clear_artists(clear_preview=True)
+
+    assert renderer.preview_artists == []
+    assert renderer.selection_artists == []
+    assert len(polar_ax.lines) == 0
+
+
+def test_clear_artists_removes_selection_artists_only(polar_ax):
+    """clear_artists removes selection artists when clear_preview is False."""
+    renderer = SelectionRenderer(polar_ax)
+
+    edge = DummyEdge(endpoint1=(1.0, 0.0), endpoint2=(1.0, np.pi))
+    renderer.draw_bin_edges([edge], preview=False)
+
+    renderer.clear_artists(clear_preview=False)
+
+    assert renderer.preview_artists == []
+    assert renderer.selection_artists == []
+    assert len(polar_ax.lines) == 0


### PR DESCRIPTION
## Description
This PR merges the SelectionRenderer class and its associated unit tests to main. This is the last support component before merging SiteSelector itself.

## Usage Changes
None. This is not user facing.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Implements SelectionRenderer class that draws things and keeps track of what's been drawn
  - [x] Implements unit tests 
  - [x] Adds the readme diagrams from branch 58

## Pre-Review checklist (PR maker)
- [x] New functions are documented
- [x] All tests pass

## Review checklist (Reviewer)
- [x] New functions are documented 
- [x] New functions/variables are named appropriately
- [x] No missed "low-hanging fruit" that would substantially aid readability.
- [x] Any "high-hanging" or "rotten" fruit is added to the issues list.
- [x] I understand what the changes are doing and how
- [x] I understand the motivation for this PR (the PR itself is appropriately documented)
- [x] All checks pass (CI is automatic in this repo)

## Status
- [x] Ready for review
