### PR TITLE
281 error in tcl will not stop GitHub action

### DIFF
--- a/.github/workflows/install_vmd_and_run_tests.yml
+++ b/.github/workflows/install_vmd_and_run_tests.yml
@@ -119,7 +119,7 @@ jobs:
           cd $GITHUB_WORKSPACE/test_files/
           echo "Running polarDensityBin.tcl on test systems in preparation for acceptance testing."
           vmd -dispdev none -e ./run_dta_for_regr_test.tcl 2>&1 | tee ./run_dta_for_regr_test.log
-          if grep -q -e "can't" -e "couldn't" ./run_dta_for_regr_test.log
+          if grep -q -e "can't" -e "couldn't" -e "failed" ./run_dta_for_regr_test.log
           then
             echo "An error occurred when running polarDensityBin.tcl on the test systems"
             exit 1

--- a/.github/workflows/install_vmd_and_run_tests.yml
+++ b/.github/workflows/install_vmd_and_run_tests.yml
@@ -119,7 +119,7 @@ jobs:
           cd $GITHUB_WORKSPACE/test_files/
           echo "Running polarDensityBin.tcl on test systems in preparation for acceptance testing."
           vmd -dispdev none -e ./run_dta_for_regr_test.tcl 2>&1 | tee ./run_dta_for_regr_test.log
-          if grep -q -e "can't" -e "couldn't" ./run_dta_for_regr_test.log
+          if grep -q -e "can't" -e "couldn't" -e "fail" ./run_dta_for_regr_test.log
           then
             echo "An error occurred when running polarDensityBin.tcl on the test systems"
             exit 1

--- a/.github/workflows/install_vmd_and_run_tests.yml
+++ b/.github/workflows/install_vmd_and_run_tests.yml
@@ -119,7 +119,7 @@ jobs:
           cd $GITHUB_WORKSPACE/test_files/
           echo "Running polarDensityBin.tcl on test systems in preparation for acceptance testing."
           vmd -dispdev none -e ./run_dta_for_regr_test.tcl 2>&1 | tee ./run_dta_for_regr_test.log
-          if grep -q -e "can't" -e "couldn't" -e "fail" ./run_dta_for_regr_test.log
+          if grep -q -e "can't" -e "couldn't" ./run_dta_for_regr_test.log
           then
             echo "An error occurred when running polarDensityBin.tcl on the test systems"
             exit 1

--- a/test_files/MD_files/rep1/config_for_regr_test.tcl
+++ b/test_files/MD_files/rep1/config_for_regr_test.tcl
@@ -3,7 +3,7 @@
 # 1 for legacy sorting based on orientation of default termini (aka classic local_mid_plane); 
 # 2 for sorting based on position relative to origin (tested only with cholesterol so far) 
 set leaflet_sorting_algorithm 3; 
-set restrict_leaflet_sorter_to_Rmax 2;
+set restrict_leaflet_sorter_to_Rmax 1;
 
 set center_and_align 1
 set use_qwrap 0

--- a/test_files/MD_files/rep1/config_for_regr_test.tcl
+++ b/test_files/MD_files/rep1/config_for_regr_test.tcl
@@ -3,7 +3,7 @@
 # 1 for legacy sorting based on orientation of default termini (aka classic local_mid_plane); 
 # 2 for sorting based on position relative to origin (tested only with cholesterol so far) 
 set leaflet_sorting_algorithm 3; 
-set restrict_leaflet_sorter_to_Rmax 1;
+set restrict_leaflet_sorter_to_Rmax 2;
 
 set center_and_align 1
 set use_qwrap 0

--- a/test_files/run_dta_for_regr_test.tcl
+++ b/test_files/run_dta_for_regr_test.tcl
@@ -16,9 +16,14 @@ proc load_and_run_test {trajpath groname xtcname config home} {
 }
 
 ;# Put your tests below
-
-;# ELIC in 95% POPC 5% Cardiolipin membrane
-set path [file normalize [file join $scriptDir "MD_files/rep1/test_vals"]]
-load_and_run_test $path ../example.gro ../example.xtc ${path}/../config_for_regr_test.tcl $scriptDir
+if {[catch {
+	;# ELIC in 95% POPC 5% Cardiolipin membrane
+	set path [file normalize [file join $scriptDir "MD_files/rep1/test_vals"]]
+	load_and_run_test $path ../example.gro ../example.xtc ${path}/../config_for_regr_test.tcl $scriptDir
+} err opts]} {
+	puts stderr "Tcl script failed inside VMD:"
+    puts stderr $err
+    puts stderr [dict get $opts -errorinfo]
+}
 
 exit

--- a/test_files/run_dta_for_regr_test.tcl
+++ b/test_files/run_dta_for_regr_test.tcl
@@ -16,16 +16,9 @@ proc load_and_run_test {trajpath groname xtcname config home} {
 }
 
 ;# Put your tests below
-if {[catch {
-	;# ELIC in 95% POPC 5% Cardiolipin membrane
-	set path [file normalize [file join $scriptDir "MD_files/rep1/test_vals"]]
-	load_and_run_test $path ../example.gro ../example.xtc ${path}/../config_for_regr_test.tcl $scriptDir
-} err opts]} {
-	puts stderr "Tcl script failed inside VMD:"
-    puts stderr $err
-    puts stderr [dict get $opts -errorinfo]
 
-	exit 1
-}
+;# ELIC in 95% POPC 5% Cardiolipin membrane
+set path [file normalize [file join $scriptDir "MD_files/rep1/test_vals"]]
+load_and_run_test $path ../example.gro ../example.xtc ${path}/../config_for_regr_test.tcl $scriptDir
 
-exit 0
+exit

--- a/test_files/run_dta_for_regr_test.tcl
+++ b/test_files/run_dta_for_regr_test.tcl
@@ -16,9 +16,16 @@ proc load_and_run_test {trajpath groname xtcname config home} {
 }
 
 ;# Put your tests below
+if {[catch {
+	;# ELIC in 95% POPC 5% Cardiolipin membrane
+	set path [file normalize [file join $scriptDir "MD_files/rep1/test_vals"]]
+	load_and_run_test $path ../example.gro ../example.xtc ${path}/../config_for_regr_test.tcl $scriptDir
+} err opts]} {
+	puts stderr "Tcl script failed inside VMD:"
+    puts stderr $err
+    puts stderr [dict get $opts -errorinfo]
 
-;# ELIC in 95% POPC 5% Cardiolipin membrane
-set path [file normalize [file join $scriptDir "MD_files/rep1/test_vals"]]
-load_and_run_test $path ../example.gro ../example.xtc ${path}/../config_for_regr_test.tcl $scriptDir
+	exit 1
+}
 
-exit
+exit 0


### PR DESCRIPTION
## Description
VMD will not return an error code when it exits. This means that if something fails during the dta.tcl part of the code in acceptance testing, the github action will conclude normally. In most cases acceptance tests will still fail, but the actual error is hidden in a different section of the action report. With this change, an error when executing polarDensityBin in vmd will cause the github action to fail on that step of the action rather than advance.

## Usage Changes
None.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Add error reporting to acceptance test script
  - [x] Add additional keyword to search for after action completion

## Pre-Review checklist (PR maker)
- [x] Test to make sure an error is properly caught (see screenshot)
<img width="1456" height="830" alt="image" src="https://github.com/user-attachments/assets/f5cead13-2640-449c-b658-d6eb0173879f" />
