### PR TITLE
Make end_frame inclusive, remove 2-stage leaflet sorting, and minor tidying

### DIFF
--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -81,7 +81,7 @@ proc output_inclusion_centers {{a ""} } {
     global params
     ;# list for the chain names
     ;# finds the center of the membranes
-    set midplane_height [z_mid $params(start_frame) $params(end_frame)]
+    set midplane_height [z_mid $params(start_frame) [expr $params(end_frame) + 1]]
     ;# calculates the center of mass for subunit alpha helices in both leaflets
     puts "Writing coordinates for [llength $params(chainlist)] chains and [llength $params(helixlist)] helices per chain"
     foreach eq {"<" ">"} eqtxt {"lwr" "upr"} {
@@ -363,7 +363,7 @@ proc frame_leaflet_assignment {atseltext headname tailname frame_i frame_f {rest
 
         set leaflet_list [$sel_to_sort get user2] 
         set sel_to_update [atomselect top "index [$sel_to_sort get index]"]
-        for {set unsorted_frame [expr $frame_i + 1]} {$unsorted_frame < [expr $frame_f]} {incr unsorted_frame} {
+        for {set unsorted_frame [expr $frame_i + 1]} {$unsorted_frame < $frame_f} {incr unsorted_frame} {
             $sel_to_update frame $unsorted_frame
             $sel_to_update update
             $sel_to_update set user2 $leaflet_list
@@ -397,14 +397,8 @@ proc trajectory_leaflet_assignment {atseltext headname tailname} {
                 puts "Defaulting to z=0 as the reference height to sort by."
         }
     }
-    for {set update_frame $params(start_frame)} {$update_frame <= [expr $params(end_frame) - $params(leaflet_reassign_interval)]} {incr update_frame $params(leaflet_reassign_interval)} {
+    for {set update_frame $params(start_frame)} {$update_frame <= $params(end_frame)} {incr update_frame $params(leaflet_reassign_interval)} {
         frame_leaflet_assignment $atseltext $headname $tailname $update_frame [expr $update_frame + $params(leaflet_reassign_interval)] $params(restrict_leaflet_sorter_to_Rmax)
-        incr num_reassignments
-    }
-    if {[test_if_evenly_divisible $params(end_frame) $params(leaflet_reassign_interval)] != 1} {
-        # Run one extra iteration to finish final leftover frames at end of trajectory.
-
-        frame_leaflet_assignment $atseltext $headname $tailname $update_frame $params(end_frame) $params(restrict_leaflet_sorter_to_Rmax)
         incr num_reassignments
     }
     puts "Checked for leaflet reassignments $num_reassignments times."
@@ -416,7 +410,7 @@ proc clean_leaflet_assignments {atseltext} {
     set sel [ atomselect top "$atseltext"]
     set selnum [$sel num]
 
-    for {set update_frame $params(start_frame)} {$update_frame < $params(end_frame)} {incr update_frame} {
+    for {set update_frame $params(start_frame)} {$update_frame <= $params(end_frame)} {incr update_frame} {
         $sel frame $update_frame
         $sel set user2 [lrepeat $selnum 0.0]
         puts "Cleaning $selnum beads of leaflet assignments in frame $update_frame"
@@ -523,7 +517,7 @@ proc histogramAllFramesOfShell {shellSelText startFrame endFrame shellStart shel
     set totalBinCounts [lrepeat $params(Ntheta) 0]
     set shellSel [atomselect top "$shellSelText and (user2 $leafletID)"]
     set errorCheck [atomselect top "($shellSelText) and not (user2 1.0 '-1.0')"]
-    for {set frm $startFrame} {$frm < $endFrame} {incr frm $params(dt)} {
+    for {set frm $startFrame} {$frm <= $endFrame} {incr frm $params(dt)} {
         $shellSel frame $frm
         $shellSel update
         $errorCheck frame $frm
@@ -610,7 +604,7 @@ proc set_parameters { config_file_script } {
         filename_stems {"POPG"}
     }
     set nframes [molinfo top get numframes] 
-    array set params [list end_frame $nframes]
+    array set params [list end_frame [expr $nframes - 1]]
 
     set param_name_list [lsort -dictionary [array names params]]
     source $config_file_script

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -52,25 +52,25 @@ proc get_theta {x y} {
     return [RtoD $theta]
 }
 
-# z_mid
+# getAvgHeight
 #
-# Finds the average mid-plane
+# Finds the z coordinate of the center of mass of a selection, averaged over time.
 # Arguments:
-#   int: first frame
-#   nframes: The number of frames over which to average
+#   atomselection: The selection you want to measure the z-COM of.
+#   int: starting frame.
+#   int: ending frame (inclusive).
+#   int: time step in frames. default is 1 frame.
 # Outputs:
-#   float: The average z value of all the beads
-#
-
-proc z_mid {init_frm nframes} {
+#   float: The average z-value of all the atoms in the selection, weighted by mass.
+proc getAvgHeight {sel startFrm endFrm {step 1}} {
     global params
     set z_list {}
-    for {set frm ${init_frm}} {${frm} < ${nframes}} {incr frm} {
-        set mid [atomselect top $params(midplane_selstr) frame $frm]
+    for {set frm $startFrm} {$frm <= $endFrm} {incr frm $step} {
+        $sel frame $frm
+        $sel update
         lappend z_list [lindex [measure center $mid weight mass] 2]
-        $mid delete
     }
-    return [expr 1.0*[vecsum $z_list]/([llength $z_list]) ]
+    return [vecmean $z_list]
 }
 
 
@@ -81,7 +81,9 @@ proc output_inclusion_centers {{a ""} } {
     global params
     ;# list for the chain names
     ;# finds the center of the membranes
-    set midplane_height [z_mid $params(start_frame) [expr $params(end_frame) + 1]]
+    set inclusionSel [atomselect top $params(midplane_selstr)]
+    set midplane_height [getAvgHeight $inclusionSel $params(start_frame) $params(end_frame)]
+    $inclusionSel delete
     ;# calculates the center of mass for subunit alpha helices in both leaflets
     puts "Writing coordinates for [llength $params(chainlist)] chains and [llength $params(helixlist)] helices per chain"
     foreach eq {"<" ">"} eqtxt {"lwr" "upr"} {

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -666,6 +666,16 @@ proc polarDensityBin { config_file_script } {
             error "No lipid of matching atomselection text $atseltext"
         }
 
+        set nframes [molinfo top get numframes]
+        if { $params(start_frame) > $nframes } {
+            puts "Warning: specified start frame $params(start_frame) is greater than number of frames $nframes" 
+            set params(start_frame) $nframes
+        }
+        if { $params(end_frame) >= $nframes } {
+            puts "Warning: specified end frame $params(end_frame) is greater than number of frames; setting end frame to [expr $nframes - 1]" 
+            set params(end_frame) [expr $nframes - 1]
+        }
+
         if {$params(center_and_align) == 1} {
             ;# wraps and centers system at origin
             center_and_wrap_system "occupancy $params(helixlist) and $params(backbone_selstr)"
@@ -674,17 +684,8 @@ proc polarDensityBin { config_file_script } {
         }
         ;# outputs protein positions
         output_inclusion_centers
-        ;# initialize some constants
+
         set area [get_avg_area]
-        set nframes [molinfo top get numframes]
-        if { $params(start_frame) > $nframes } {
-            puts "Warning: specified start frame $params(start_frame) is greater than number of frames $nframes" 
-            set params(start_frame) $nframes
-        }
-        if { $params(end_frame) > $nframes } {
-            puts "Warning: specified end frame $params(end_frame) is greater than number of frames; setting end frame to $nframes" 
-            set params(end_frame) $nframes
-        }
 
         puts "Atomselection:\t$atseltext"
         set low_f [open "${stem}.low.dat" w]

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -563,7 +563,7 @@ proc histogramAllFramesOfShell {shellSelText startFrame endFrame shellStart shel
 #    Bin information is saved to user fields (via assignBins).
 proc calculateAvgCountsByShell {atselText lowerCountsOutfile upperCountsOutfile lowerAvgOutfile upperAvgOutfile} {
     global params
-    set delta_frame [expr {int(ceil(double($params(end_frame) - $params(start_frame) + 1.0) / $params(dt)))}]
+    set deltaFrame [expr {int(ceil(double($params(end_frame) - $params(start_frame) + 1.0) / $params(dt)))}]
     foreach leafletID "'-1.0' 1.0" countsOutfile [list $lowerCountsOutfile $upperCountsOutfile] avgCountsOutfile [list $lowerAvgOutfile $upperAvgOutfile] leafletStr "inner outer" {
         set radialIndex 0
         for {set ri $params(Rmin)} {$ri<$params(Rmax)} {set ri [expr $ri + $params(dr)]} {

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -502,7 +502,7 @@ proc assignBins {atsel numAngularBins radialIndex} {
 #    str: The atomselection text for every atom (bead) of interest in the
 #        radial shell.
 #    int: The frame number from which to start the loop.
-#    int: The frame upon which to end the loop (not inclusive).
+#    int: The frame upon which to end the loop (inclusive).
 #    float: The lower radial coordinate of the bin edge.
 #    float: The upper radial coordinate of the bin edge.
 #    channel: The counts output file.

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -344,6 +344,10 @@ proc frame_leaflet_assignment {atseltext headname tailname frame_i frame_f {rest
     } else {
         error "restrict_leaflet_sorter_to_Rmax must be 1 or 0"
     }
+    if {$frame_f > $params(end_frame)} {
+        set frame_f $parames(end_frame) 
+    }
+
     set sel_num [llength [lsort -unique [$sel_to_sort get resid] ] ]
     set sel_resid_list [lsort -unique [$sel_to_sort get resid] ]
     set totals {}
@@ -362,7 +366,6 @@ proc frame_leaflet_assignment {atseltext headname tailname frame_i frame_f {rest
         # Copy leaflet values from $frame_i to all frames between $frame_i and 
         # $frame_f. Use index numbers for this, since $sel is based off of a 
         # radial shell when $restrict_to_Rmax is on.
-
         set leaflet_list [$sel_to_sort get user2] 
         set sel_to_update [atomselect top "index [$sel_to_sort get index]"]
         for {set unsorted_frame [expr $frame_i + 1]} {$unsorted_frame < $frame_f} {incr unsorted_frame} {

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -345,7 +345,7 @@ proc frame_leaflet_assignment {atseltext headname tailname frame_i frame_f {rest
         error "restrict_leaflet_sorter_to_Rmax must be 1 or 0"
     }
     if {$frame_f > $params(end_frame)} {
-        set frame_f $parames(end_frame) 
+        set frame_f $params(end_frame) 
     }
 
     set sel_num [llength [lsort -unique [$sel_to_sort get resid] ] ]

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -670,9 +670,8 @@ proc polarDensityBin { config_file_script } {
         }
 
         set nframes [molinfo top get numframes]
-        if { $params(start_frame) > $nframes } {
-            puts "Warning: specified start frame $params(start_frame) is greater than number of frames $nframes" 
-            set params(start_frame) $nframes
+        if { $params(start_frame) >= $nframes } {
+            error "Error: specified start frame $params(start_frame) exceeds final frame [expr $nframes - 1]" 
         }
         if { $params(end_frame) >= $nframes } {
             puts "Warning: specified end frame $params(end_frame) is greater than number of frames; setting end frame to [expr $nframes - 1]" 

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -68,7 +68,7 @@ proc getAvgHeight {sel startFrm endFrm {step 1}} {
     for {set frm $startFrm} {$frm <= $endFrm} {incr frm $step} {
         $sel frame $frm
         $sel update
-        lappend z_list [lindex [measure center $mid weight mass] 2]
+        lappend z_list [lindex [measure center $sel weight mass] 2]
     }
     return [vecmean $z_list]
 }

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -368,7 +368,7 @@ proc frame_leaflet_assignment {atseltext headname tailname frame_i frame_f {rest
         # radial shell when $restrict_to_Rmax is on.
         set leaflet_list [$sel_to_sort get user2] 
         set sel_to_update [atomselect top "index [$sel_to_sort get index]"]
-        for {set unsorted_frame [expr $frame_i + 1]} {$unsorted_frame < $frame_f} {incr unsorted_frame} {
+        for {set unsorted_frame [expr $frame_i + 1]} {$unsorted_frame <= $frame_f} {incr unsorted_frame} {
             $sel_to_update frame $unsorted_frame
             $sel_to_update update
             $sel_to_update set user2 $leaflet_list

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -559,7 +559,7 @@ proc histogramAllFramesOfShell {shellSelText startFrame endFrame shellStart shel
 #    Bin information is saved to user fields (via assignBins).
 proc calculateAvgCountsByShell {atselText lowerCountsOutfile upperCountsOutfile lowerAvgOutfile upperAvgOutfile} {
     global params
-    set deltaFrame [expr {int(ceil(double($params(end_frame) - $params(start_frame) + 1.0) / $params(dt)))}]
+    set numSamples [expr {int(ceil(double($params(end_frame) - $params(start_frame) + 1.0) / $params(dt)))}]
     foreach leafletID "'-1.0' 1.0" countsOutfile [list $lowerCountsOutfile $upperCountsOutfile] avgCountsOutfile [list $lowerAvgOutfile $upperAvgOutfile] leafletStr "inner outer" {
         set radialIndex 0
         for {set ri $params(Rmin)} {$ri<$params(Rmax)} {set ri [expr $ri + $params(dr)]} {
@@ -569,7 +569,7 @@ proc calculateAvgCountsByShell {atselText lowerCountsOutfile upperCountsOutfile 
             set rf2 [expr $rf*$rf]
             set shellSelText "($atselText) and ((x*x + y*y < $rf2) and  (x*x + y*y > $ri2))"
             set totalHistogram [histogramAllFramesOfShell $shellSelText $params(start_frame) $params(end_frame) $ri $rf $countsOutfile $radialIndex $leafletID]
-            set timeAvg [vecscale $totalHistogram [expr 1.0 / (1.0 * $deltaFrame)]]
+            set timeAvg [vecscale $totalHistogram [expr 1.0 / (1.0 * $numSamples)]]
             output_bins $avgCountsOutfile $ri $rf "$timeAvg"
             incr radialIndex
         }

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -563,7 +563,7 @@ proc histogramAllFramesOfShell {shellSelText startFrame endFrame shellStart shel
 #    Bin information is saved to user fields (via assignBins).
 proc calculateAvgCountsByShell {atselText lowerCountsOutfile upperCountsOutfile lowerAvgOutfile upperAvgOutfile} {
     global params
-    set deltaFrame [expr ($params(end_frame) - $params(start_frame)) / $params(dt)]
+    set delta_frame [expr {int(ceil(double($params(end_frame) - $params(start_frame) + 1.0) / $params(dt)))}]
     foreach leafletID "'-1.0' 1.0" countsOutfile [list $lowerCountsOutfile $upperCountsOutfile] avgCountsOutfile [list $lowerAvgOutfile $upperAvgOutfile] leafletStr "inner outer" {
         set radialIndex 0
         for {set ri $params(Rmin)} {$ri<$params(Rmax)} {set ri [expr $ri + $params(dr)]} {

--- a/TCL/polarDensity_for_DTA.tcl
+++ b/TCL/polarDensity_for_DTA.tcl
@@ -353,30 +353,29 @@ proc frame_leaflet_assignment {atseltext headname tailname frame_i frame_f {rest
     set totals {}
     if {$sel_num < 1} {
         # No lipids to sort. Return zeros.
-
         set totals [list "lower 0 0" "upper 0 0"] 
     } else {
         # Assign user2 values for of each bead of each lipid in the selection.
-
         foreach sel_resid $sel_resid_list {
             set selstring "(${atseltext}) and (resid $sel_resid)"
             leaflet_detector $selstring $headname $tailname $frame_i $params(leaflet_sorting_algorithm)
         }
 
-        # Copy leaflet values from $frame_i to all frames between $frame_i and 
-        # $frame_f. Use index numbers for this, since $sel is based off of a 
-        # radial shell when $restrict_to_Rmax is on.
-        set leaflet_list [$sel_to_sort get user2] 
-        set sel_to_update [atomselect top "index [$sel_to_sort get index]"]
-        for {set unsorted_frame [expr $frame_i + 1]} {$unsorted_frame <= $frame_f} {incr unsorted_frame} {
-            $sel_to_update frame $unsorted_frame
-            $sel_to_update update
-            $sel_to_update set user2 $leaflet_list
+        if {$frame_i < $params(end_frame)} {
+            # Copy leaflet values from $frame_i to all frames between $frame_i and 
+            # $frame_f. Use index numbers for this, since $sel is based off of a 
+            # radial shell when $restrict_to_Rmax is on.
+            set leaflet_list [$sel_to_sort get user2] 
+            set sel_to_update [atomselect top "index [$sel_to_sort get index]"]
+            for {set unsorted_frame [expr $frame_i + 1]} {$unsorted_frame <= $frame_f} {incr unsorted_frame} {
+                $sel_to_update frame $unsorted_frame
+                $sel_to_update update
+                $sel_to_update set user2 $leaflet_list
+            }
+            $sel_to_update delete
         }
-        $sel_to_update delete
 
         # Count the number of lipids and the number of beads in each leaflet.
-
         foreach leaf [list  "(user2<0)" "(user2>0)"] txtstr [list "lower" "upper"] {
             set leaf_sel [ atomselect top "(${atseltext}) and $leaf"  frame $frame_i]
             set num_beads [$leaf_sel num]

--- a/test_files/MD_files/rep1/config_for_regr_test.tcl
+++ b/test_files/MD_files/rep1/config_for_regr_test.tcl
@@ -12,7 +12,7 @@ set utils "../../../../TCL/utilities"
 set dt 1
 #set leaflet_reassign_interval 1; #optional
 #set start_frame 0 ; #optional
-set end_frame 9  ; #optional 
+set end_frame 10  ; #optional 
 
 set backbone_selstr "name BB" ;#selection string used to define the protein backbone
 set protein_selstr "name BB SC1 to SC4" ;#selection string used to define the entire protein

--- a/test_files/MD_files/rep1/config_for_regr_test.tcl
+++ b/test_files/MD_files/rep1/config_for_regr_test.tcl
@@ -12,7 +12,7 @@ set utils "../../../../TCL/utilities"
 set dt 1
 #set leaflet_reassign_interval 1; #optional
 #set start_frame 0 ; #optional
-#set end_frame 10  ; #optional 
+set end_frame 9  ; #optional 
 
 set backbone_selstr "name BB" ;#selection string used to define the protein backbone
 set protein_selstr "name BB SC1 to SC4" ;#selection string used to define the entire protein


### PR DESCRIPTION
## Description
This PR combines several small changes into one medium-sized PR. 

The first issue (#308) is that end_frame was defined as exclusive. This means that if a user had frames 0 through 9 loaded in vmd but wanted to analyze the whole trajectory, they would need to set $end_frame to 10. This is confusing as there is no frame 10 in this situation. end_frame is now inclusive, which means to analyze the full trajectory the user will set end_frame to 9 (or leave it unset, so that it defaults to 9).

The second issue (#318) is that leaflet sorting when $leaflet_reassign_interval > 1 could over-run the end of the trajectory. To prevent this, we had a confusing two-stage leaflet sorting system. This has been fixed with a simple conditional.

The third issue (#305) is that the delta_frame calculation could result in incorrect averages calculated due to truncation during integer division. This has been fixed, and delta_frame has been renamed to sampleNumber.

In the course of these changes, z_mid was refactored and renamed to getAvgHeight (Issue #309).

## Usage Changes
$params(end_frame) is now inclusive (and the documentation is updated to reflect this).
$params(end_frame) will now default to the end frame, not the number of frames. 
$delta_frame is now $numSamples. 
z_mid is now getAvgHeight. 
If a user sets start_frame to exceed the number of frames available they will get an error instead of a nonsensical warning.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] end_frame is now inclusive
  - [x] end_frame now defaults to numframes - 1 (rather than numframes)
  - [x] frame_leaflet_assignment no longer has two stages
  - [x] Fix delta_frame calculation so that it won't break
  - [x] Refactor z_mid
  - [x] Switch warning to error

## Pre-Review checklist (PR maker)
- [x] New functions are documented
- [x] New configuration parameters are documented (Usage changes above)
- [x] All checks pass
- [x] coderabbit review engaged with

## Review checklist (Reviewer)
- [x] New functions are documented 
- [ ] New functions/variables are named appropriately
- [ ] No missed "low-hanging fruit" that would substantially aid readability.
- [ ] Any "high-hanging" or "rotten" fruit is added to the issues list.
- [x] I understand what the changes are doing and how
- [ ] I understand the motivation for this PR (the PR itself is appropriately documented)

## Status
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected trajectory frame processing to include the configured final frame.
  * Improved leaflet reassignment and cleanup across the complete frame range.
  * Corrected average histogram normalization for inclusive frame ranges.

* **Improvements**
  * Updated inclusion-center height calculations to use mass-weighted averages across configurable frame ranges.
  * Adjusted default end-frame handling for more accurate trajectory analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->