### PR TITLE
Replace naive divisibility check and add helix_color arg

### DIFF
--- a/python/dta/density.py
+++ b/python/dta/density.py
@@ -9,7 +9,7 @@ from typing import Literal
 from pathlib import Path
 from collections import namedtuple
 import numpy as np
-from dta.utils import validate_path, confirm_objs_are_equal
+from dta.utils import validate_path, confirm_objs_are_equal, evenly_divided_quotient
 from dta.bin_logic import PolarBinGrid
 
 SysInfo = namedtuple('SysInfo', ['NL', 'NB', 'BoxArea', 'ExpBeadDensity', 'DrDtheta'])
@@ -274,13 +274,9 @@ def _create_grid_from_dat_file(dat_file_contents: np.ndarray) -> PolarBinGrid:
     r_min = dat_file_contents[0, 0]
     d_r = dat_file_contents[0, 1] - r_min
     r_max = np.max(dat_file_contents[:, 1])
-    if ((r_max - r_min) % d_r) > 1e-8:
-        raise ValueError(f"Range {r_max - r_min} not evenly divisible by {d_r}")
-    n_r = (r_max - r_min) // d_r
+    n_r = evenly_divided_quotient((r_max - r_min), d_r)
     d_theta_degrees = dat_file_contents[0, 2]
-    if 360 % d_theta_degrees > 1e-8:
-        raise ValueError(f"360 is not evenly divisible by {d_theta_degrees}")
-    n_theta = 360 // d_theta_degrees
+    n_theta = evenly_divided_quotient(360, d_theta_degrees)
     grid = PolarBinGrid(r_min, r_max, int(n_r), int(n_theta))
     return grid
 

--- a/python/dta/density.py
+++ b/python/dta/density.py
@@ -274,11 +274,11 @@ def _create_grid_from_dat_file(dat_file_contents: np.ndarray) -> PolarBinGrid:
     r_min = dat_file_contents[0, 0]
     d_r = dat_file_contents[0, 1] - r_min
     r_max = np.max(dat_file_contents[:, 1])
-    if ((r_max - r_min) % d_r) != 0:
+    if ((r_max - r_min) % d_r) > 1e-8:
         raise ValueError(f"Range {r_max - r_min} not evenly divisible by {d_r}")
     n_r = (r_max - r_min) // d_r
     d_theta_degrees = dat_file_contents[0, 2]
-    if 360 % d_theta_degrees != 0:
+    if 360 % d_theta_degrees > 1e-8:
         raise ValueError(f"360 is not evenly divisible by {d_theta_degrees}")
     n_theta = 360 // d_theta_degrees
     grid = PolarBinGrid(r_min, r_max, int(n_r), int(n_theta))

--- a/python/dta/plotting.py
+++ b/python/dta/plotting.py
@@ -177,7 +177,7 @@ def create_heatmap_figure_and_axes(heatmap_settings: HeatmapSettings) -> plt.Fig
     return fig
 
 
-def plot_helices_on_panels(fig: plt.Figure, helices: list[np.ndarray]):
+def plot_helices_on_panels(fig: plt.Figure, helices: list[np.ndarray], helix_colors: list[str] | None = None):
     """
     Plot helix locations on each panel present in the figure.
 
@@ -187,6 +187,8 @@ def plot_helices_on_panels(fig: plt.Figure, helices: list[np.ndarray]):
         The Figure containing your heatmap panels.
     helices : list of numpy ndarrays
         List containing one set of helix coordinates per panel.
+    helix_colors : list of str or None
+        Optional list containing matplotlib-recognized colors. Default is None.
 
     Returns
     -------
@@ -196,9 +198,10 @@ def plot_helices_on_panels(fig: plt.Figure, helices: list[np.ndarray]):
     """
     if not isinstance(helices, list):
         raise TypeError(f"{helices} must be a list instead of a {type(helices)}.")
-    assert len(helices) == np.ravel(fig.axes).shape[0]
+    if len(helices) != np.ravel(fig.axes).shape[0]:
+        raise RuntimeError("Need to provide as many sets of helices as there are axes.")
     for ax, helix_set in zip(np.ravel(fig.axes), helices):
-        ax = plot_helices(helix_set, False, ax, 50)
+        ax = plot_helices(helix_set, False, ax, 50, helix_colors)
     return fig
 
 
@@ -452,7 +455,7 @@ def plot_helices(helices, colorbychain, ax, markersize=3, colorlist=None):
     return ax
 
 
-def make_density_enrichment_heatmap(enrichments_list, helices, heatmap_settings):
+def make_density_enrichment_heatmap(enrichments_list, helices, heatmap_settings, helix_colors=None):
     """
     Make a figure and axes objects. Plot heatmaps of density enrichment for each\
     system on each axes object. Return the figure and axes.
@@ -467,6 +470,8 @@ def make_density_enrichment_heatmap(enrichments_list, helices, heatmap_settings)
         ndarray per heatmap.
     heatmap_settings : HeatmapSettings object
         Contains all of the auxiliary information needed to plot heatmaps.
+    helix_colors : list or None
+        Optional list of matplotlib-recognized colors. Default is None.
 
     Returns
     -------
@@ -488,7 +493,7 @@ def make_density_enrichment_heatmap(enrichments_list, helices, heatmap_settings)
     if len(enrichments_list) != axes.shape[0]:
         raise IndexError(f"Number of enrichments_list items ({len(enrichments_list)}) does not match number of figure panels ({axes.shape[0]}).")
 
-    fig = plot_helices_on_panels(fig, helices)
+    fig = plot_helices_on_panels(fig, helices, helix_colors)
     for index, ax in enumerate(axes):
         ax = plot_heatmap(ax, enrichments_list[index], heatmap_settings)
     fig = make_colorbar(fig, heatmap_settings)

--- a/python/dta/plotting.py
+++ b/python/dta/plotting.py
@@ -200,7 +200,7 @@ def plot_helices_on_panels(fig: plt.Figure, helices: list[np.ndarray], helix_col
         raise TypeError(f"{helices} must be a list instead of a {type(helices)}.")
     if len(helices) != np.ravel(fig.axes).shape[0]:
         raise RuntimeError("Need to provide as many sets of helices as there are axes.")
-    for ax, helix_set in zip(np.ravel(fig.axes), helices):
+    for ax, helix_set in zip(np.ravel(fig.axes), helices, strict=True):
         ax = plot_helices(helix_set, False, ax, 50, helix_colors)
     return fig
 

--- a/python/dta/utils.py
+++ b/python/dta/utils.py
@@ -337,6 +337,8 @@ def evenly_divided_quotient(dividend: float, divisor: float) -> int:
     int
         The dividend divided evenly by the divisor.
     """
+    if divisor == 0:
+        raise ValueError("divisor cannot be 0.")
     quotient = dividend / divisor
     nearest_integer = round(quotient)
 

--- a/python/dta/utils.py
+++ b/python/dta/utils.py
@@ -316,3 +316,19 @@ def confirm_objs_are_equal(list_of_objs: list) -> None:
             raise TypeError(f"Expected {obj_type} but {obj} is a {type(obj)}")
         if obj != compare_to:
             raise ValueError(f"{inspect.getmembers(obj)} does not match {inspect.getmembers(compare_to)}")
+
+
+def evenly_divided_quotient(value, divisor):
+    """Determine if divisor can divide value evenly, then return integer quotient."""
+    quotient = value / divisor
+    nearest_integer = round(quotient)
+
+    if not math.isclose(
+        quotient,
+        nearest_integer,
+        rel_tol=1e-9,
+        abs_tol=1e-12,
+    ):
+        raise ValueError(f"{value} is not evenly divisible by {divisor}")
+
+    return nearest_integer

--- a/python/dta/utils.py
+++ b/python/dta/utils.py
@@ -318,9 +318,26 @@ def confirm_objs_are_equal(list_of_objs: list) -> None:
             raise ValueError(f"{inspect.getmembers(obj)} does not match {inspect.getmembers(compare_to)}")
 
 
-def evenly_divided_quotient(value, divisor):
-    """Determine if divisor can divide value evenly, then return integer quotient."""
-    quotient = value / divisor
+def evenly_divided_quotient(dividend: float, divisor: float) -> int:
+    """
+    Determine if divisor can divide dividend evenly; error if not.
+
+    Parameters
+    ----------
+    dividend : float
+    divisor : float
+
+    Raises
+    ------
+    ValueError
+        If the dividend is not evenly divisible by the divisor.
+
+    Returns
+    -------
+    int
+        The dividend divided evenly by the divisor.
+    """
+    quotient = dividend / divisor
     nearest_integer = round(quotient)
 
     if not math.isclose(
@@ -329,6 +346,6 @@ def evenly_divided_quotient(value, divisor):
         rel_tol=1e-9,
         abs_tol=1e-12,
     ):
-        raise ValueError(f"{value} is not evenly divisible by {divisor}")
+        raise ValueError(f"{dividend} is not evenly divisible by {divisor}")
 
     return nearest_integer

--- a/python/dta/utils.py
+++ b/python/dta/utils.py
@@ -345,7 +345,7 @@ def evenly_divided_quotient(dividend: float, divisor: float) -> int:
     if not math.isclose(
         quotient,
         nearest_integer,
-        rel_tol=1e-9,
+        rel_tol=0.0,
         abs_tol=1e-12,
     ):
         raise ValueError(f"{dividend} is not evenly divisible by {divisor}")

--- a/python/dta/utils.py
+++ b/python/dta/utils.py
@@ -322,6 +322,9 @@ def evenly_divided_quotient(dividend: float, divisor: float) -> int:
     """
     Determine if divisor can divide dividend evenly; error if not.
 
+    Near-integer quotients are accepted and rounded to int if within 1e-12 of
+    an integer.
+
     Parameters
     ----------
     dividend : float
@@ -330,7 +333,7 @@ def evenly_divided_quotient(dividend: float, divisor: float) -> int:
     Raises
     ------
     ValueError
-        If the dividend is not evenly divisible by the divisor.
+        If the dividend is greater than 1e-12 away from an integer value.
 
     Returns
     -------


### PR DESCRIPTION
## Description
We were using a naive error check for even divisibility that failed due to floating-point fragility. The specific failure was on a grid with 50 angular bins, 360 % 7.2 does not evaluate to 0 even though it should. This has been fixed by introducing a robust divisibility check util function.

We also did not have a way of easily allowing the user to change the colors of their helices. While `plot_helices` had the ability to take a `colorlist` argument, there was nothing that would allow the user to access that argument without completely remaking their own plotting script. This has been fixed.

## Usage Changes
`make_density_enrichment_heatmap` now has an optional `helix_colors` argument.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Add divisibility check function
  - [x] Confirm that it fixes @JohannahStevenson's problem
  - [x] Pipe `helix_colors` to `plot_helices`

## Pre-Review checklist (PR maker)
- [x] New functions are documented
- [x] New functions work as intended
- [x] Testing still passes
- [x] Engage with all coderabbit comments

## Review checklist (Reviewer)
- [ ] New functions are documented 
- [ ] New functions/variables are named appropriately
- [ ] No missed "low-hanging fruit" that would substantially aid readability.
- [ ] Any "high-hanging" or "rotten" fruit is added to the issues list.
- [ ] I understand what the changes are doing and how
- [ ] I understand the motivation for this PR (the PR itself is appropriately documented)

## Status
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved grid validation to prevent valid radial and angular dimensions from being rejected بسبب minor floating-point calculation differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->